### PR TITLE
feat: bootstrap CardForge prototype

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./prisma/dev.db"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+.env
+.env.local
+.prisma
+pnpm-lock.yaml
+yarn.lock
+package-lock.json
+prisma/dev.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# CardForge – Kortspelsbyggare
+
+CardForge är ett Next.js-projekt som låter designers bygga, validera och exportera kort till egna kortspel. Prototypen omfattar en avancerad korteditor med live-preview, central nyckelordshantering, deck-check och exportpanel.
+
+## Funktioner
+
+- **Korteditor** med Zod-validering och realtidsförhandsvisning.
+- **Nyckelordshantering** med möjlighet att lägga till egna nyckelord.
+- **Deck-check** för att säkerställa att lekar följer formatregler.
+- **Exportpanel** för JSON, PNG och PDF (de sistnämnda som stubbar).
+- **Prisma-schema** för att modellera kort, set, nyckelord och lekar.
+
+## Kom igång
+
+1. Installera beroenden:
+
+   ```bash
+   npm install
+   ```
+
+2. Kopiera `.env.example` till `.env` och justera vid behov:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Kör databas-migreringar och generera Prisma-klienten:
+
+   ```bash
+   npx prisma db push
+   npx prisma generate
+   ```
+
+4. Starta utvecklingsservern:
+
+   ```bash
+   npm run dev
+   ```
+
+## API-översikt
+
+- `POST /api/cards` – Validerar och sparar ett nytt kort i databasen.
+- `GET /api/cards` – Returnerar listan över skapade kort inklusive nyckelord och setinformation.
+- `POST /api/decks/validate` – Validerar att en lek följer formatreglerna.
+
+## Testning och kvalitet
+
+Projektet använder `next lint` för statisk analys. Kör:
+
+```bash
+npm run lint
+```
+
+## Vidare utveckling
+
+- Implementera riktig PNG/PDF-export.
+- Koppla korteditorn till API-routes för att spara och ladda kort.
+- Lägg till autentisering och användarhantering.
+
+Lycka till med vidareutvecklingen av CardForge!

--- a/app/api/cards/route.ts
+++ b/app/api/cards/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { cardSchema } from "@/lib/validators";
+
+export async function GET() {
+  try {
+    const cards = await prisma.card.findMany({
+      include: {
+        keywords: {
+          include: {
+            keyword: true
+          }
+        },
+        set: true
+      },
+      orderBy: {
+        createdAt: "desc"
+      }
+    });
+
+    return NextResponse.json(cards);
+  } catch (error) {
+    console.error("Failed to fetch cards", error);
+    return NextResponse.json({ message: "Kunde inte hämta kort." }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = await request.json();
+    const parsed = cardSchema.safeParse(payload);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { message: "Validering misslyckades", issues: parsed.error.issues },
+        { status: 422 }
+      );
+    }
+
+    const card = await prisma.card.create({
+      data: {
+        name: parsed.data.name,
+        cost: parsed.data.cost,
+        type: parsed.data.type,
+        rarity: parsed.data.rarity,
+        text: parsed.data.text ?? "",
+        imageUrl: parsed.data.imageUrl,
+        attack: parsed.data.stats.attack,
+        health: parsed.data.stats.health,
+        armor: parsed.data.stats.armor ?? 0,
+        expansion: parsed.data.expansion,
+        version: parsed.data.version,
+        set: {
+          connectOrCreate: {
+            where: { code: parsed.data.setId },
+            create: {
+              code: parsed.data.setId,
+              name: `${parsed.data.setId} Set`,
+              version: parsed.data.version
+            }
+          }
+        },
+        keywords: {
+          create: parsed.data.keywords.map((keyword) => ({
+            keyword: {
+              connectOrCreate: {
+                where: { name: keyword },
+                create: {
+                  name: keyword
+                }
+              }
+            }
+          }))
+        }
+      },
+      include: {
+        keywords: {
+          include: { keyword: true }
+        },
+        set: true
+      }
+    });
+
+    return NextResponse.json(card, { status: 201 });
+  } catch (error) {
+    console.error("Failed to create card", error);
+    return NextResponse.json({ message: "Något gick fel vid skapandet." }, { status: 500 });
+  }
+}

--- a/app/api/decks/validate/route.ts
+++ b/app/api/decks/validate/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { deckSchema } from "@/lib/validators";
+
+export async function POST(request: Request) {
+  const payload = await request.json();
+  const parsed = deckSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { message: "Leken misslyckades med validering", issues: parsed.error.issues },
+      { status: 422 }
+    );
+  }
+
+  return NextResponse.json({ message: "Leken är giltig" });
+}

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { type ReactNode, useMemo, useState } from "react";
+import { Combobox } from "@headlessui/react";
+import { CheckIcon, ChevronUpDownIcon, PlusIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { KEYWORDS } from "@/lib/keywords";
+import type { CardFormValues } from "@/lib/types";
+import { validateCard } from "@/lib/validators";
+import clsx from "classnames";
+
+const defaultValues: CardFormValues = {
+  name: "",
+  cost: 1,
+  type: "Creature",
+  rarity: "Common",
+  text: "",
+  imageUrl: "",
+  stats: { attack: 1, health: 1, armor: 0 },
+  keywords: [],
+  setId: "CORE",
+  expansion: "Genesis",
+  version: "v1.0.0"
+};
+
+interface CardEditorProps {
+  onChange?: (values: CardFormValues) => void;
+}
+
+export function CardEditor({ onChange }: CardEditorProps) {
+  const [values, setValues] = useState<CardFormValues>(defaultValues);
+  const [keywordQuery, setKeywordQuery] = useState("");
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const filteredKeywords = useMemo(() => {
+    const lower = keywordQuery.toLowerCase();
+    return KEYWORDS.filter((keyword) => keyword.toLowerCase().includes(lower));
+  }, [keywordQuery]);
+
+  function handleChange<T>(key: keyof CardFormValues, value: T) {
+    setValues((prev) => {
+      const updated = { ...prev, [key]: value } as CardFormValues;
+      onChange?.(updated);
+      return updated;
+    });
+  }
+
+  function handleStatChange(stat: "attack" | "health" | "armor", value: number) {
+    const safeValue = Number.isNaN(value)
+      ? stat === "health"
+        ? 1
+        : 0
+      : value;
+    setValues((prev) => {
+      const updated = {
+        ...prev,
+        stats: { ...prev.stats, [stat]: safeValue }
+      };
+      onChange?.(updated);
+      return updated;
+    });
+  }
+
+  function addKeyword(keyword: string) {
+    if (!keyword || values.keywords.includes(keyword)) return;
+    const updated = { ...values, keywords: [...values.keywords, keyword] };
+    setValues(updated);
+    onChange?.(updated);
+    setKeywordQuery("");
+  }
+
+  function removeKeyword(keyword: string) {
+    const updated = {
+      ...values,
+      keywords: values.keywords.filter((item) => item !== keyword)
+    };
+    setValues(updated);
+    onChange?.(updated);
+  }
+
+  function handleValidate() {
+    const result = validateCard(values);
+    if (!result.success) {
+      const formatted = result.error.issues.reduce<Record<string, string>>((acc, issue) => {
+        const path = issue.path.join(".") || "form";
+        acc[path] = issue.message;
+        return acc;
+      }, {});
+      setErrors(formatted);
+    } else {
+      setErrors({});
+    }
+    return result;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl">
+        <header className="mb-6 flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-white">Korteditor</h2>
+            <p className="text-sm text-slate-400">
+              Ange kortdetaljer och få live-validering enligt spelreglerna.
+            </p>
+          </div>
+          <button type="button" onClick={handleValidate} className="bg-primary-500 px-4 py-2 text-sm font-semibold">
+            Validera kort
+          </button>
+        </header>
+
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <Field label="Namn" error={errors.name}>
+            <input
+              name="name"
+              value={values.name}
+              onChange={(event) => handleChange("name", event.target.value)}
+              placeholder="Ex. Stjärnvandrare"
+            />
+          </Field>
+
+          <Field label="Kostnad" error={errors.cost}>
+            <input
+              type="number"
+              name="cost"
+              min={0}
+              max={15}
+              value={values.cost}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                handleChange("cost", Number.isNaN(value) ? 0 : value);
+              }}
+            />
+          </Field>
+
+          <Field label="Korttyp" error={errors.type}>
+            <select value={values.type} onChange={(event) => handleChange("type", event.target.value as CardFormValues["type"]) }>
+              <option value="Creature">Varelse</option>
+              <option value="Spell">Besvärjelse</option>
+              <option value="Artifact">Artefakt</option>
+              <option value="Hero">Hjälte</option>
+            </select>
+          </Field>
+
+          <Field label="Sällsynthet" error={errors.rarity}>
+            <select
+              value={values.rarity}
+              onChange={(event) => handleChange("rarity", event.target.value as CardFormValues["rarity"])}
+            >
+              <option value="Common">Common</option>
+              <option value="Uncommon">Uncommon</option>
+              <option value="Rare">Rare</option>
+              <option value="Mythic">Mythic</option>
+            </select>
+          </Field>
+
+          <Field label="Set-ID" error={errors.setId}>
+            <input
+              name="setId"
+              value={values.setId}
+              onChange={(event) => handleChange("setId", event.target.value)}
+            />
+          </Field>
+
+          <Field label="Expansion" error={errors.expansion}>
+            <input
+              name="expansion"
+              value={values.expansion}
+              onChange={(event) => handleChange("expansion", event.target.value)}
+            />
+          </Field>
+
+          <Field label="Version" error={errors.version}>
+            <input
+              name="version"
+              value={values.version}
+              onChange={(event) => handleChange("version", event.target.value)}
+            />
+          </Field>
+
+          <Field label="Bild URL" error={errors.imageUrl}>
+            <input
+              name="imageUrl"
+              value={values.imageUrl}
+              onChange={(event) => handleChange("imageUrl", event.target.value)}
+              placeholder="https://"
+            />
+          </Field>
+
+          <Field label="Attack" error={errors["stats.attack"]}>
+            <input
+              type="number"
+              min={0}
+              max={20}
+              value={values.stats.attack}
+              onChange={(event) => handleStatChange("attack", Number(event.target.value))}
+            />
+          </Field>
+
+          <Field label="Liv" error={errors["stats.health"]}>
+            <input
+              type="number"
+              min={1}
+              max={25}
+              value={values.stats.health}
+              onChange={(event) => handleStatChange("health", Number(event.target.value))}
+            />
+          </Field>
+
+          <Field label="Rustning" error={errors["stats.armor"]}>
+            <input
+              type="number"
+              min={0}
+              max={10}
+              value={values.stats.armor ?? 0}
+              onChange={(event) => handleStatChange("armor", Number(event.target.value))}
+            />
+          </Field>
+        </div>
+
+        <Field label="Korttext" error={errors.text}>
+          <textarea
+            rows={4}
+            value={values.text}
+            onChange={(event) => handleChange("text", event.target.value)}
+            placeholder={"Beskriv kortets effekt och eventuella regler."}
+          />
+        </Field>
+
+        <div className="space-y-2">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Nyckelord</label>
+          <KeywordSelector
+            selectedKeywords={values.keywords}
+            onAddKeyword={addKeyword}
+            onRemoveKeyword={removeKeyword}
+            query={keywordQuery}
+            onQueryChange={setKeywordQuery}
+            suggestions={filteredKeywords}
+          />
+          {errors.keywords ? <p className="text-sm text-rose-400">{errors.keywords}</p> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  error,
+  children
+}: {
+  label: string;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <label>{label}</label>
+      {children}
+      {error ? <p className="text-sm text-rose-400">{error}</p> : null}
+    </div>
+  );
+}
+
+interface KeywordSelectorProps {
+  selectedKeywords: string[];
+  suggestions: string[];
+  query: string;
+  onQueryChange: (value: string) => void;
+  onAddKeyword: (keyword: string) => void;
+  onRemoveKeyword: (keyword: string) => void;
+}
+
+function KeywordSelector({
+  selectedKeywords,
+  suggestions,
+  query,
+  onQueryChange,
+  onAddKeyword,
+  onRemoveKeyword
+}: KeywordSelectorProps) {
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-slate-950/70 p-4">
+      <Combobox value={query} onChange={onAddKeyword}>
+        <div className="relative">
+          <div className="relative w-full cursor-default overflow-hidden rounded-lg text-left shadow-md focus:outline-none">
+            <Combobox.Input
+              className="w-full border border-slate-700 bg-slate-900 py-2 pl-3 pr-10 text-sm leading-5 text-slate-100"
+              displayValue={() => query}
+              onChange={(event) => onQueryChange(event.target.value)}
+              placeholder="Sök efter nyckelord"
+            />
+            <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2 text-slate-400">
+              <ChevronUpDownIcon className="h-5 w-5" aria-hidden="true" />
+            </Combobox.Button>
+          </div>
+          {suggestions.length > 0 ? (
+            <Combobox.Options className="absolute z-10 mt-1 max-h-40 w-full overflow-auto rounded-md bg-slate-900 py-1 text-sm shadow-lg ring-1 ring-black/5">
+              {suggestions.map((keyword) => (
+                <Combobox.Option
+                  key={keyword}
+                  value={keyword}
+                  className={({ active }) =>
+                    clsx(
+                      "relative cursor-default select-none py-2 pl-8 pr-4",
+                      active ? "bg-primary-600 text-white" : "text-slate-100"
+                    )
+                  }
+                >
+                  {({ active }) => (
+                    <>
+                      <span className="block truncate">{keyword}</span>
+                      {active ? (
+                        <span className="absolute inset-y-0 left-0 flex items-center pl-2 text-white">
+                          <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                        </span>
+                      ) : null}
+                    </>
+                  )}
+                </Combobox.Option>
+              ))}
+            </Combobox.Options>
+          ) : null}
+        </div>
+      </Combobox>
+
+      <div className="flex flex-wrap gap-2">
+        {selectedKeywords.map((keyword) => (
+          <span
+            key={keyword}
+            className="inline-flex items-center gap-2 rounded-full bg-primary-500/20 px-3 py-1 text-xs font-medium text-primary-200"
+          >
+            {keyword}
+            <button
+              type="button"
+              onClick={() => onRemoveKeyword(keyword)}
+              className="rounded-full bg-primary-500/30 p-0.5 text-primary-100 hover:bg-primary-500/60"
+            >
+              <XMarkIcon className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+        <button
+          type="button"
+          onClick={() => (query ? onAddKeyword(query) : null)}
+          className="inline-flex items-center gap-1 text-xs font-medium text-primary-300"
+        >
+          <PlusIcon className="h-4 w-4" />
+          Lägg till
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/CardPreview.tsx
+++ b/app/components/CardPreview.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Image from "next/image";
+import type { CardFormValues } from "@/lib/types";
+import clsx from "classnames";
+
+interface CardPreviewProps {
+  card: CardFormValues;
+}
+
+export function CardPreview({ card }: CardPreviewProps) {
+  return (
+    <div className="card-surface relative flex h-[460px] w-[320px] flex-col overflow-hidden rounded-3xl border border-white/10 p-4 text-slate-100">
+      <header className="card-header relative flex items-center justify-between rounded-2xl px-4 py-2 text-slate-50 shadow-lg">
+        <span className="text-lg font-semibold uppercase tracking-wide">
+          {card.name || "Nytt kort"}
+        </span>
+        <span className="badge bg-white/20 text-base font-bold text-slate-900">
+          {card.cost}
+        </span>
+      </header>
+
+      <div className="mt-4 flex-1 overflow-hidden rounded-2xl border border-white/10 bg-slate-900/70">
+        {card.imageUrl ? (
+          <Image
+            src={card.imageUrl}
+            alt={card.name}
+            width={288}
+            height={200}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
+            Ingen bild vald
+          </div>
+        )}
+      </div>
+
+      <div className="mt-4 rounded-2xl bg-slate-900/70 p-4 text-sm">
+        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+          <span>{card.type}</span>
+          <span>{card.rarity}</span>
+        </div>
+        <p className="mt-2 whitespace-pre-line text-slate-100">
+          {card.text || "Korttext visas här. Beskriv effekter och regler."}
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {card.keywords.length > 0 ? (
+            card.keywords.map((keyword) => (
+              <span key={keyword} className="badge">
+                {keyword}
+              </span>
+            ))
+          ) : (
+            <span className="text-xs text-slate-500">Inga nyckelord</span>
+          )}
+        </div>
+      </div>
+
+      <footer className="mt-3 flex items-center justify-between rounded-2xl bg-slate-900/70 px-4 py-2">
+        <div className="flex items-center gap-3 text-slate-200">
+          <StatBadge label="ATK" value={card.stats.attack} />
+          <StatBadge label="HP" value={card.stats.health} />
+          {card.stats.armor ? <StatBadge label="ARM" value={card.stats.armor} /> : null}
+        </div>
+        <div className="text-right text-[11px] uppercase text-slate-500">
+          <div>
+            Set: <span className="text-slate-300">{card.setId || "—"}</span>
+          </div>
+          <div>
+            Expansion: <span className="text-slate-300">{card.expansion || "—"}</span>
+          </div>
+          <div>
+            Version: <span className="text-slate-300">{card.version || "v1.0.0"}</span>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+function StatBadge({ label, value }: { label: string; value: number }) {
+  return (
+    <span
+      className={clsx(
+        "flex h-12 w-12 flex-col items-center justify-center rounded-full border border-slate-700 bg-slate-950/80 text-xs font-bold",
+        "shadow-inner shadow-black/60"
+      )}
+    >
+      <span className="text-[10px] text-slate-500">{label}</span>
+      <span className="text-lg text-slate-100">{value}</span>
+    </span>
+  );
+}

--- a/app/components/DeckBuilder.tsx
+++ b/app/components/DeckBuilder.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useState } from "react";
+import { validateDeck } from "@/lib/validators";
+import type { DeckFormValues } from "@/lib/types";
+import { PlusIcon } from "@heroicons/react/24/outline";
+
+const MOCK_LIBRARY = [
+  { id: "c1", name: "Stjärnvandrare", type: "Creature", rarity: "Rare" },
+  { id: "c2", name: "Energisprång", type: "Spell", rarity: "Common" },
+  { id: "c3", name: "Temporal Ward", type: "Artifact", rarity: "Uncommon" }
+];
+
+const defaultDeck: DeckFormValues = {
+  name: "Ny lek",
+  format: "standard",
+  cards: []
+};
+
+export function DeckBuilder() {
+  const [deck, setDeck] = useState<DeckFormValues>(defaultDeck);
+  const [cardId, setCardId] = useState(MOCK_LIBRARY[0]?.id ?? "");
+  const [quantity, setQuantity] = useState(1);
+  const [validationMessage, setValidationMessage] = useState<string | null>(null);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  function addCardToDeck() {
+    if (!cardId) return;
+    setDeck((prev) => {
+      const existing = prev.cards.find((card) => card.cardId === cardId);
+      const updatedCards = existing
+        ? prev.cards.map((card) =>
+            card.cardId === cardId
+              ? { ...card, quantity: Math.min(card.quantity + quantity, 4) }
+              : card
+          )
+        : [...prev.cards, { cardId, quantity }];
+      return { ...prev, cards: updatedCards };
+    });
+    setQuantity(1);
+  }
+
+  function removeCard(id: string) {
+    setDeck((prev) => ({
+      ...prev,
+      cards: prev.cards.filter((card) => card.cardId !== id)
+    }));
+  }
+
+  function validate() {
+    const result = validateDeck(deck);
+    if (result.success) {
+      setErrors([]);
+      setValidationMessage("Leken följer formatreglerna!");
+    } else {
+      setValidationMessage(null);
+      setErrors(result.error.issues.map((issue) => issue.message));
+    }
+  }
+
+  const totalCards = deck.cards.reduce((sum, item) => sum + item.quantity, 0);
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-white">Deck-check</h2>
+          <p className="text-sm text-slate-400">
+            Bygg en lek och kontrollera att den följer begränsningar per format.
+          </p>
+        </div>
+        <button type="button" onClick={validate}>
+          Validera lek
+        </button>
+      </header>
+
+      <div className="space-y-4">
+        <div className="flex flex-col gap-4 md:flex-row">
+          <div className="flex-1 space-y-2">
+            <label>Leknamn</label>
+            <input
+              value={deck.name}
+              onChange={(event) => setDeck((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="Ex. Aether Rush"
+            />
+          </div>
+          <div className="w-full space-y-2 md:w-48">
+            <label>Format</label>
+            <select
+              value={deck.format}
+              onChange={(event) => setDeck((prev) => ({ ...prev, format: event.target.value as DeckFormValues["format"] }))}
+            >
+              <option value="standard">Standard</option>
+              <option value="unlimited">Unlimited</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-white/5 bg-slate-950/70 p-4">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Lägg till kort</h3>
+          <div className="mt-3 flex flex-col gap-3 lg:flex-row">
+            <div className="flex flex-1 flex-col gap-2">
+              <label>Kort</label>
+              <select value={cardId} onChange={(event) => setCardId(event.target.value)} className="bg-slate-900">
+                {MOCK_LIBRARY.map((card) => (
+                  <option key={card.id} value={card.id}>
+                    {card.name} – {card.type}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="w-full space-y-2 lg:w-32">
+              <label>Antal</label>
+              <input
+                type="number"
+                min={1}
+                max={4}
+                value={quantity}
+                onChange={(event) => {
+                  const value = Number(event.target.value);
+                  if (Number.isNaN(value)) {
+                    setQuantity(1);
+                    return;
+                  }
+                  setQuantity(Math.min(4, Math.max(1, value)));
+                }}
+              />
+            </div>
+            <button type="button" onClick={addCardToDeck} className="lg:w-44">
+              <PlusIcon className="mr-2 h-4 w-4" />
+              Lägg till kort
+            </button>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-white/5 bg-slate-950/70 p-4">
+          <header className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+              Kortlista ({totalCards} kort)
+            </h3>
+            <span className="text-xs text-slate-500">Max 60 kort</span>
+          </header>
+          <ul className="mt-3 space-y-2 text-sm text-slate-200">
+            {deck.cards.length === 0 ? (
+              <li className="text-xs text-slate-500">Inga kort har lagts till ännu.</li>
+            ) : (
+              deck.cards.map((entry) => {
+                const card = MOCK_LIBRARY.find((item) => item.id === entry.cardId);
+                return (
+                  <li key={entry.cardId} className="flex items-center justify-between rounded-xl bg-slate-900/70 px-3 py-2">
+                    <div>
+                      <p className="font-medium text-slate-100">{card?.name ?? entry.cardId}</p>
+                      <p className="text-xs text-slate-500">
+                        {card?.type ?? "Okänd typ"} • {card?.rarity ?? "?"}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-4 text-sm">
+                      <span className="badge bg-primary-500/20 text-primary-200">x{entry.quantity}</span>
+                      <button
+                        type="button"
+                        onClick={() => removeCard(entry.cardId)}
+                        className="text-xs text-rose-300 hover:text-rose-200"
+                      >
+                        Ta bort
+                      </button>
+                    </div>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </div>
+
+        {validationMessage ? (
+          <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">
+            {validationMessage}
+          </div>
+        ) : null}
+
+        {errors.length > 0 ? (
+          <div className="rounded-xl border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-200">
+            <ul className="list-inside list-disc space-y-1">
+              {errors.map((error, index) => (
+                <li key={`${error}-${index}`}>{error}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/app/components/ExportPanel.tsx
+++ b/app/components/ExportPanel.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { CardFormValues } from "@/lib/types";
+import { DocumentArrowDownIcon } from "@heroicons/react/24/outline";
+
+interface ExportPanelProps {
+  card: CardFormValues;
+}
+
+export function ExportPanel({ card }: ExportPanelProps) {
+  const [format, setFormat] = useState<"json" | "png" | "pdf">("json");
+
+  const jsonPreview = useMemo(() => JSON.stringify(card, null, 2), [card]);
+
+  function handleExport() {
+    switch (format) {
+      case "json":
+        downloadFile("card.json", jsonPreview);
+        break;
+      case "png":
+        alert("PNG-export kräver serverrendering av kortlayout. Stub implementerad för prototyp.");
+        break;
+      case "pdf":
+        alert("PDF-export bygger på framtida print-and-play generator.");
+        break;
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-white">Export</h2>
+          <p className="text-sm text-slate-400">
+            Ladda ner kortdata i olika format för integration eller utskrift.
+          </p>
+        </div>
+        <button type="button" onClick={handleExport}>
+          <DocumentArrowDownIcon className="mr-2 h-5 w-5" />
+          Exportera {format.toUpperCase()}
+        </button>
+      </header>
+
+      <div className="flex flex-col gap-4 lg:flex-row">
+        <div className="flex w-full flex-col gap-2 lg:w-40">
+          <label>Format</label>
+          <select value={format} onChange={(event) => setFormat(event.target.value as typeof format)}>
+            <option value="json">JSON</option>
+            <option value="png">PNG</option>
+            <option value="pdf">PDF</option>
+          </select>
+        </div>
+        <div className="flex-1">
+          <label>Förhandsgranskning (JSON)</label>
+          <pre className="mt-2 h-64 overflow-auto rounded-2xl border border-white/5 bg-slate-950/70 p-4 text-xs text-slate-200">
+            {jsonPreview}
+          </pre>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function downloadFile(filename: string, content: string) {
+  const element = document.createElement("a");
+  element.setAttribute(
+    "href",
+    "data:text/plain;charset=utf-8," + encodeURIComponent(content)
+  );
+  element.setAttribute("download", filename);
+  element.style.display = "none";
+  document.body.appendChild(element);
+  element.click();
+  document.body.removeChild(element);
+}

--- a/app/components/KeywordManager.tsx
+++ b/app/components/KeywordManager.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { keywordGroups, KEYWORDS } from "@/lib/keywords";
+import { PlusIcon } from "@heroicons/react/24/outline";
+
+export function KeywordManager() {
+  const [customKeywords, setCustomKeywords] = useState<string[]>([]);
+  const [newKeyword, setNewKeyword] = useState("");
+
+  function handleAddKeyword() {
+    if (!newKeyword) return;
+    const formatted = newKeyword
+      .trim()
+      .replace(/\s+/g, " ")
+      .replace(/^\w/, (char) => char.toUpperCase());
+    if (formatted && !customKeywords.includes(formatted) && !KEYWORDS.includes(formatted)) {
+      setCustomKeywords((prev) => [...prev, formatted]);
+      setNewKeyword("");
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl">
+      <header className="mb-6">
+        <h2 className="text-xl font-semibold text-white">Nyckelordshantering</h2>
+        <p className="text-sm text-slate-400">
+          Centralt register för kortnyckelord. Lägg till egna termer och se vilka kortkategorier de tillhör.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {keywordGroups.map((group) => (
+          <article key={group.name} className="rounded-2xl border border-white/5 bg-slate-950/70 p-4">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-primary-300">{group.name}</h3>
+            <ul className="mt-2 space-y-2 text-sm text-slate-200">
+              {group.keywords.map((keyword) => (
+                <li key={keyword} className="flex items-center justify-between">
+                  <span>{keyword}</span>
+                  <span className="text-xs text-slate-500">Core</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+
+      <div className="mt-6 rounded-2xl border border-dashed border-white/10 bg-slate-950/60 p-4">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Lägg till eget nyckelord</h3>
+        <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+          <input
+            value={newKeyword}
+            onChange={(event) => setNewKeyword(event.target.value)}
+            placeholder="Ex. Chronoshift"
+            className="flex-1"
+          />
+          <button type="button" onClick={handleAddKeyword} className="sm:w-36">
+            <PlusIcon className="mr-2 h-4 w-4" />
+            Lägg till
+          </button>
+        </div>
+        {customKeywords.length > 0 ? (
+          <ul className="mt-3 flex flex-wrap gap-2 text-xs text-primary-200">
+            {customKeywords.map((keyword) => (
+              <li key={keyword} className="rounded-full bg-primary-500/20 px-3 py-1">
+                {keyword}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,43 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 min-h-screen;
+}
+
+a {
+  @apply text-primary-300 hover:text-primary-200;
+}
+
+input, textarea, select {
+  @apply bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500;
+}
+
+label {
+  @apply text-xs font-semibold uppercase tracking-wide text-slate-400;
+}
+
+button {
+  @apply inline-flex items-center justify-center rounded-md bg-primary-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-400 disabled:opacity-60 disabled:cursor-not-allowed;
+}
+
+.card-surface {
+  background: radial-gradient(circle at top left, rgba(139, 92, 246, 0.35), transparent 60%),
+    radial-gradient(circle at bottom right, rgba(14, 116, 144, 0.25), transparent 55%),
+    linear-gradient(145deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.95));
+  box-shadow: 0 20px 40px -20px rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.card-header {
+  background: linear-gradient(120deg, rgba(139, 92, 246, 0.9), rgba(14, 165, 233, 0.7));
+}
+
+.badge {
+  @apply rounded-full bg-slate-800/60 px-2.5 py-1 text-xs font-medium uppercase tracking-wide text-slate-300;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,23 @@
+import "./globals.css";
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "CardForge – Kortspelsbyggare",
+  description:
+    "Bygg, hantera och validera kort för egna kortspel med CardForge."
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="sv" className="bg-slate-950">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { CardEditor } from "@/app/components/CardEditor";
+import { CardPreview } from "@/app/components/CardPreview";
+import { DeckBuilder } from "@/app/components/DeckBuilder";
+import { ExportPanel } from "@/app/components/ExportPanel";
+import { KeywordManager } from "@/app/components/KeywordManager";
+import type { CardFormValues } from "@/lib/types";
+
+const initialCard: CardFormValues = {
+  name: "Stjärnvandrare",
+  cost: 4,
+  type: "Creature",
+  rarity: "Rare",
+  text: "När Stjärnvandrare kommer i spel, dra ett kort.\nBerserk: +2 attack under din tur.",
+  imageUrl: "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=400&q=80",
+  stats: { attack: 3, health: 4, armor: 0 },
+  keywords: ["Berserk", "Momentum"],
+  setId: "CORE",
+  expansion: "Genesis",
+  version: "v1.0.0"
+};
+
+export default function HomePage() {
+  const [card, setCard] = useState<CardFormValues>(initialCard);
+
+  return (
+    <main className="mx-auto max-w-7xl space-y-10 px-4 py-10">
+      <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-white sm:text-4xl">CardForge</h1>
+          <p className="mt-2 max-w-2xl text-base text-slate-400">
+            Webbaserat verktyg för att skapa, validera och exportera kort till egna kortspel. Designa kort,
+            hantera nyckelord och säkerställ att lekar följer formatregler.
+          </p>
+        </div>
+        <div className="rounded-3xl border border-primary-500/30 bg-primary-500/10 px-6 py-4 text-sm text-primary-100 shadow-lg">
+          <p className="font-semibold uppercase tracking-wide text-primary-300">Snabbstatus</p>
+          <ul className="mt-2 space-y-1 text-primary-100">
+            <li>✔ Kortvalidering med Zod</li>
+            <li>✔ Nyckelordshantering</li>
+            <li>✔ Deck-check för Standard och Unlimited</li>
+            <li>✔ Export till JSON / PNG / PDF (stub)</li>
+          </ul>
+        </div>
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+        <CardEditor onChange={setCard} />
+        <div className="flex flex-col items-center justify-start gap-6">
+          <CardPreview card={card} />
+          <ExportPanel card={card} />
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <KeywordManager />
+        <DeckBuilder />
+      </section>
+    </main>
+  );
+}

--- a/lib/keywords.ts
+++ b/lib/keywords.ts
@@ -1,0 +1,29 @@
+export const KEYWORDS = [
+  "Charge",
+  "Stealth",
+  "Taunt",
+  "Lifesteal",
+  "Overwhelm",
+  "Ward",
+  "Empower",
+  "Berserk",
+  "Momentum",
+  "Quickdraw",
+  "Pierce",
+  "Retaliate"
+];
+
+export const keywordGroups = [
+  {
+    name: "Offensiva",
+    keywords: ["Charge", "Berserk", "Quickdraw", "Pierce"]
+  },
+  {
+    name: "Defensiva",
+    keywords: ["Taunt", "Ward", "Retaliate"]
+  },
+  {
+    name: "Utility",
+    keywords: ["Stealth", "Lifesteal", "Overwhelm", "Momentum", "Empower"]
+  }
+];

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,18 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient({
+  log: ["query", "error", "warn"],
+  datasources: {
+    db: {
+      url: process.env.DATABASE_URL ?? "file:./prisma/dev.db"
+    }
+  }
+});
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,33 @@
+export type CardType = "Creature" | "Spell" | "Artifact" | "Hero";
+export type CardRarity = "Common" | "Uncommon" | "Rare" | "Mythic";
+
+export interface CardStats {
+  attack: number;
+  health: number;
+  armor?: number;
+}
+
+export interface CardFormValues {
+  name: string;
+  cost: number;
+  type: CardType;
+  rarity: CardRarity;
+  text: string;
+  imageUrl: string;
+  stats: CardStats;
+  keywords: string[];
+  setId: string;
+  expansion: string;
+  version: string;
+}
+
+export interface DeckCardEntry {
+  cardId: string;
+  quantity: number;
+}
+
+export interface DeckFormValues {
+  name: string;
+  format: "standard" | "unlimited";
+  cards: DeckCardEntry[];
+}

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import type { CardFormValues, DeckFormValues } from "./types";
+
+export const cardSchema = z
+  .object({
+    name: z.string().min(3, "Namnet måste vara minst 3 tecken."),
+    cost: z.number().int().min(0).max(15),
+    type: z.enum(["Creature", "Spell", "Artifact", "Hero"]),
+    rarity: z.enum(["Common", "Uncommon", "Rare", "Mythic"]),
+    text: z.string().max(800).optional().default(""),
+    imageUrl: z.string().url("Ogiltig bildadress."),
+    stats: z.object({
+      attack: z.number().int().min(0).max(20),
+      health: z.number().int().min(1).max(25),
+      armor: z.number().int().min(0).max(10).optional().default(0)
+    }),
+    keywords: z.array(z.string()).max(6),
+    setId: z.string().min(2),
+    expansion: z.string().min(2),
+    version: z.string().regex(/^v\d+\.\d+\.\d+$/, "Version måste följa formatet vX.Y.Z"),
+    createdAt: z.date().optional(),
+    updatedAt: z.date().optional()
+  })
+  .superRefine((data, ctx) => {
+    if (data.type === "Creature" && data.stats.attack === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Varelser bör ha minst 1 attack.",
+        path: ["stats", "attack"]
+      });
+    }
+    if (data.keywords.includes("Berserk") && data.stats.health < 2) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Berserk kräver minst 2 liv.",
+        path: ["stats", "health"]
+      });
+    }
+  });
+
+export const deckSchema = z
+  .object({
+    name: z.string().min(3),
+    format: z.enum(["standard", "unlimited"]),
+    cards: z
+      .array(
+        z.object({
+          cardId: z.string(),
+          quantity: z.number().int().min(1).max(4)
+        })
+      )
+      .max(60)
+  })
+  .refine((deck) => deck.cards.reduce((sum, card) => sum + card.quantity, 0) >= 40, {
+    message: "Leken måste innehålla minst 40 kort.",
+    path: ["cards"]
+  })
+  .superRefine((deck, ctx) => {
+    if (deck.format === "standard") {
+      const duplicates = deck.cards.filter((entry) => entry.quantity > 3);
+      if (duplicates.length > 0) {
+        duplicates.forEach((entry, index) => {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Standard-format tillåter max 3 kopior av samma kort.",
+            path: ["cards", index, "quantity"]
+          });
+        });
+      }
+    }
+  });
+
+export type CardSchema = z.infer<typeof cardSchema>;
+export type DeckSchema = z.infer<typeof deckSchema>;
+
+export function validateCard(values: CardFormValues) {
+  return cardSchema.safeParse(values);
+}
+
+export function validateDeck(values: DeckFormValues) {
+  return deckSchema.safeParse(values);
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,16 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: true
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com"
+      }
+    ]
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "cardforge",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@headlessui/react": "^1.7.17",
+    "@heroicons/react": "^2.1.4",
+    "@prisma/client": "^5.11.0",
+    "classnames": "^2.5.1",
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwind-merge": "^2.2.1",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.17",
+    "@types/react": "18.2.57",
+    "@types/react-dom": "18.2.18",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0",
+    "postcss": "8.4.35",
+    "prisma": "5.11.0",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.3.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,72 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model Card {
+  id         String   @id @default(cuid())
+  name       String
+  cost       Int
+  type       String
+  rarity     String
+  text       String
+  imageUrl   String
+  attack     Int
+  health     Int
+  armor      Int      @default(0)
+  keywords   CardKeyword[]
+  set        CardSet  @relation(fields: [setId], references: [id])
+  setId      String
+  expansion  String
+  version    String
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+}
+
+model CardKeyword {
+  card     Card   @relation(fields: [cardId], references: [id])
+  cardId   String
+  keyword  Keyword @relation(fields: [keywordId], references: [id])
+  keywordId String
+
+  @@id([cardId, keywordId])
+}
+
+model Keyword {
+  id    String  @id @default(cuid())
+  name  String  @unique
+  cards CardKeyword[]
+  group String?
+}
+
+model CardSet {
+  id        String @id @default(cuid())
+  code      String @unique
+  name      String
+  version   String
+  cards     Card[]
+  createdAt DateTime @default(now())
+}
+
+model Deck {
+  id        String      @id @default(cuid())
+  name      String
+  format    String
+  cards     DeckCard[]
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
+}
+
+model DeckCard {
+  deck    Deck   @relation(fields: [deckId], references: [id])
+  deckId  String
+  card    Card   @relation(fields: [cardId], references: [id])
+  cardId  String
+  copies  Int
+
+  @@id([deckId, cardId])
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,30 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./pages/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: "#f5f3ff",
+          100: "#ede9fe",
+          200: "#ddd6fe",
+          300: "#c4b5fd",
+          400: "#a78bfa",
+          500: "#8b5cf6",
+          600: "#7c3aed",
+          700: "#6d28d9",
+          800: "#5b21b6",
+          900: "#4c1d95"
+        }
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js + Tailwind frontend with card editor, live preview and export prototype
- add supporting components for keyword management and deck validation driven by Zod schemas
- introduce Prisma data models and API routes for persisting cards and validating decks

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68caf16a8748832bae8abae5a4050882