### PR TITLE
Translate CardForge UI to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,60 @@
-# CardForge – Kortspelsbyggare
+# CardForge – Card Game Builder
 
-CardForge är ett Next.js-projekt som låter designers bygga, validera och exportera kort till egna kortspel. Prototypen omfattar en avancerad korteditor med live-preview, central nyckelordshantering, deck-check och exportpanel.
+CardForge is a Next.js project that helps designers build, validate, and export cards for custom trading card games. The prototype includes an advanced card editor with live preview, centralized keyword management, a deck validator, and export tools.
 
-## Funktioner
+## Features
 
-- **Korteditor** med Zod-validering och realtidsförhandsvisning.
-- **Nyckelordshantering** med möjlighet att lägga till egna nyckelord.
-- **Deck-check** för att säkerställa att lekar följer formatregler.
-- **Exportpanel** för JSON, PNG och PDF (de sistnämnda som stubbar).
-- **Prisma-schema** för att modellera kort, set, nyckelord och lekar.
+- **Card editor** with Zod validation and live preview.
+- **Keyword management** with support for custom entries.
+- **Deck check** to ensure lists comply with format rules.
+- **Export panel** for JSON, PNG, and PDF (PNG/PDF currently stubbed).
+- **Prisma schema** that models cards, sets, keywords, and decks.
 
-## Kom igång
+## Getting started
 
-1. Installera beroenden:
+1. Install dependencies:
 
    ```bash
    npm install
    ```
 
-2. Kopiera `.env.example` till `.env` och justera vid behov:
+2. Copy `.env.example` to `.env` and update if needed:
 
    ```bash
    cp .env.example .env
    ```
 
-3. Kör databas-migreringar och generera Prisma-klienten:
+3. Run the database migrations and generate the Prisma client:
 
    ```bash
    npx prisma db push
    npx prisma generate
    ```
 
-4. Starta utvecklingsservern:
+4. Start the development server:
 
    ```bash
    npm run dev
    ```
 
-## API-översikt
+## API overview
 
-- `POST /api/cards` – Validerar och sparar ett nytt kort i databasen.
-- `GET /api/cards` – Returnerar listan över skapade kort inklusive nyckelord och setinformation.
-- `POST /api/decks/validate` – Validerar att en lek följer formatreglerna.
+- `POST /api/cards` – Validates and persists a new card in the database.
+- `GET /api/cards` – Returns the list of created cards including keywords and set information.
+- `POST /api/decks/validate` – Validates that a deck follows the format restrictions.
 
-## Testning och kvalitet
+## Testing & quality
 
-Projektet använder `next lint` för statisk analys. Kör:
+The project uses `next lint` for static analysis. Run:
 
 ```bash
 npm run lint
 ```
 
-## Vidare utveckling
+## Future work
 
-- Implementera riktig PNG/PDF-export.
-- Koppla korteditorn till API-routes för att spara och ladda kort.
-- Lägg till autentisering och användarhantering.
+- Implement full PNG/PDF export flows.
+- Connect the card editor to the API routes for saving and loading cards.
+- Add authentication and user management.
 
-Lycka till med vidareutvecklingen av CardForge!
+Happy forging with CardForge!

--- a/app/api/cards/route.ts
+++ b/app/api/cards/route.ts
@@ -21,7 +21,7 @@ export async function GET() {
     return NextResponse.json(cards);
   } catch (error) {
     console.error("Failed to fetch cards", error);
-    return NextResponse.json({ message: "Kunde inte hämta kort." }, { status: 500 });
+    return NextResponse.json({ message: "Could not fetch cards." }, { status: 500 });
   }
 }
 
@@ -32,7 +32,7 @@ export async function POST(request: Request) {
 
     if (!parsed.success) {
       return NextResponse.json(
-        { message: "Validering misslyckades", issues: parsed.error.issues },
+        { message: "Validation failed", issues: parsed.error.issues },
         { status: 422 }
       );
     }
@@ -84,6 +84,6 @@ export async function POST(request: Request) {
     return NextResponse.json(card, { status: 201 });
   } catch (error) {
     console.error("Failed to create card", error);
-    return NextResponse.json({ message: "Något gick fel vid skapandet." }, { status: 500 });
+    return NextResponse.json({ message: "Something went wrong while creating the card." }, { status: 500 });
   }
 }

--- a/app/api/decks/validate/route.ts
+++ b/app/api/decks/validate/route.ts
@@ -7,10 +7,10 @@ export async function POST(request: Request) {
 
   if (!parsed.success) {
     return NextResponse.json(
-      { message: "Leken misslyckades med validering", issues: parsed.error.issues },
+      { message: "Deck validation failed", issues: parsed.error.issues },
       { status: 422 }
     );
   }
 
-  return NextResponse.json({ message: "Leken är giltig" });
+  return NextResponse.json({ message: "The deck is valid" });
 }

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -97,27 +97,27 @@ export function CardEditor({ onChange }: CardEditorProps) {
       <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl">
         <header className="mb-6 flex items-center justify-between">
           <div>
-            <h2 className="text-xl font-semibold text-white">Korteditor</h2>
+            <h2 className="text-xl font-semibold text-white">Card Editor</h2>
             <p className="text-sm text-slate-400">
-              Ange kortdetaljer och få live-validering enligt spelreglerna.
+              Enter card details and get live validation based on the game rules.
             </p>
           </div>
           <button type="button" onClick={handleValidate} className="bg-primary-500 px-4 py-2 text-sm font-semibold">
-            Validera kort
+            Validate card
           </button>
         </header>
 
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-          <Field label="Namn" error={errors.name}>
+          <Field label="Name" error={errors.name}>
             <input
               name="name"
               value={values.name}
               onChange={(event) => handleChange("name", event.target.value)}
-              placeholder="Ex. Stjärnvandrare"
+              placeholder="e.g. Starwanderer"
             />
           </Field>
 
-          <Field label="Kostnad" error={errors.cost}>
+          <Field label="Cost" error={errors.cost}>
             <input
               type="number"
               name="cost"
@@ -131,16 +131,19 @@ export function CardEditor({ onChange }: CardEditorProps) {
             />
           </Field>
 
-          <Field label="Korttyp" error={errors.type}>
-            <select value={values.type} onChange={(event) => handleChange("type", event.target.value as CardFormValues["type"]) }>
-              <option value="Creature">Varelse</option>
-              <option value="Spell">Besvärjelse</option>
-              <option value="Artifact">Artefakt</option>
-              <option value="Hero">Hjälte</option>
+          <Field label="Card type" error={errors.type}>
+            <select
+              value={values.type}
+              onChange={(event) => handleChange("type", event.target.value as CardFormValues["type"])}
+            >
+              <option value="Creature">Creature</option>
+              <option value="Spell">Spell</option>
+              <option value="Artifact">Artifact</option>
+              <option value="Hero">Hero</option>
             </select>
           </Field>
 
-          <Field label="Sällsynthet" error={errors.rarity}>
+          <Field label="Rarity" error={errors.rarity}>
             <select
               value={values.rarity}
               onChange={(event) => handleChange("rarity", event.target.value as CardFormValues["rarity"])}
@@ -152,7 +155,7 @@ export function CardEditor({ onChange }: CardEditorProps) {
             </select>
           </Field>
 
-          <Field label="Set-ID" error={errors.setId}>
+          <Field label="Set ID" error={errors.setId}>
             <input
               name="setId"
               value={values.setId}
@@ -176,7 +179,7 @@ export function CardEditor({ onChange }: CardEditorProps) {
             />
           </Field>
 
-          <Field label="Bild URL" error={errors.imageUrl}>
+          <Field label="Image URL" error={errors.imageUrl}>
             <input
               name="imageUrl"
               value={values.imageUrl}
@@ -195,7 +198,7 @@ export function CardEditor({ onChange }: CardEditorProps) {
             />
           </Field>
 
-          <Field label="Liv" error={errors["stats.health"]}>
+          <Field label="Health" error={errors["stats.health"]}>
             <input
               type="number"
               min={1}
@@ -205,7 +208,7 @@ export function CardEditor({ onChange }: CardEditorProps) {
             />
           </Field>
 
-          <Field label="Rustning" error={errors["stats.armor"]}>
+          <Field label="Armor" error={errors["stats.armor"]}>
             <input
               type="number"
               min={0}
@@ -216,17 +219,17 @@ export function CardEditor({ onChange }: CardEditorProps) {
           </Field>
         </div>
 
-        <Field label="Korttext" error={errors.text}>
+        <Field label="Rules text" error={errors.text}>
           <textarea
             rows={4}
             value={values.text}
             onChange={(event) => handleChange("text", event.target.value)}
-            placeholder={"Beskriv kortets effekt och eventuella regler."}
+            placeholder={"Describe the card effect and any special rules."}
           />
         </Field>
 
         <div className="space-y-2">
-          <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Nyckelord</label>
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Keywords</label>
           <KeywordSelector
             selectedKeywords={values.keywords}
             onAddKeyword={addKeyword}
@@ -286,7 +289,7 @@ function KeywordSelector({
               className="w-full border border-slate-700 bg-slate-900 py-2 pl-3 pr-10 text-sm leading-5 text-slate-100"
               displayValue={() => query}
               onChange={(event) => onQueryChange(event.target.value)}
-              placeholder="Sök efter nyckelord"
+              placeholder="Search keywords"
             />
             <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2 text-slate-400">
               <ChevronUpDownIcon className="h-5 w-5" aria-hidden="true" />
@@ -344,7 +347,7 @@ function KeywordSelector({
           className="inline-flex items-center gap-1 text-xs font-medium text-primary-300"
         >
           <PlusIcon className="h-4 w-4" />
-          Lägg till
+          Add keyword
         </button>
       </div>
     </div>

--- a/app/components/CardPreview.tsx
+++ b/app/components/CardPreview.tsx
@@ -10,10 +10,10 @@ interface CardPreviewProps {
 
 export function CardPreview({ card }: CardPreviewProps) {
   return (
-    <div className="card-surface relative flex h-[460px] w-[320px] flex-col overflow-hidden rounded-3xl border border-white/10 p-4 text-slate-100">
+    <div className="card-surface relative mx-auto flex h-[460px] w-[320px] flex-col overflow-hidden rounded-3xl border border-white/10 p-4 text-slate-100">
       <header className="card-header relative flex items-center justify-between rounded-2xl px-4 py-2 text-slate-50 shadow-lg">
         <span className="text-lg font-semibold uppercase tracking-wide">
-          {card.name || "Nytt kort"}
+          {card.name || "New card"}
         </span>
         <span className="badge bg-white/20 text-base font-bold text-slate-900">
           {card.cost}
@@ -31,7 +31,7 @@ export function CardPreview({ card }: CardPreviewProps) {
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
-            Ingen bild vald
+            No artwork selected
           </div>
         )}
       </div>
@@ -42,7 +42,7 @@ export function CardPreview({ card }: CardPreviewProps) {
           <span>{card.rarity}</span>
         </div>
         <p className="mt-2 whitespace-pre-line text-slate-100">
-          {card.text || "Korttext visas här. Beskriv effekter och regler."}
+          {card.text || "Rules text appears here. Describe effects and rules."}
         </p>
         <div className="mt-4 flex flex-wrap gap-2">
           {card.keywords.length > 0 ? (
@@ -52,7 +52,7 @@ export function CardPreview({ card }: CardPreviewProps) {
               </span>
             ))
           ) : (
-            <span className="text-xs text-slate-500">Inga nyckelord</span>
+            <span className="text-xs text-slate-500">No keywords</span>
           )}
         </div>
       </div>

--- a/app/components/DeckBuilder.tsx
+++ b/app/components/DeckBuilder.tsx
@@ -6,13 +6,13 @@ import type { DeckFormValues } from "@/lib/types";
 import { PlusIcon } from "@heroicons/react/24/outline";
 
 const MOCK_LIBRARY = [
-  { id: "c1", name: "Stjärnvandrare", type: "Creature", rarity: "Rare" },
-  { id: "c2", name: "Energisprång", type: "Spell", rarity: "Common" },
+  { id: "c1", name: "Starwanderer", type: "Creature", rarity: "Rare" },
+  { id: "c2", name: "Energy Surge", type: "Spell", rarity: "Common" },
   { id: "c3", name: "Temporal Ward", type: "Artifact", rarity: "Uncommon" }
 ];
 
 const defaultDeck: DeckFormValues = {
-  name: "Ny lek",
+  name: "New deck",
   format: "standard",
   cards: []
 };
@@ -51,7 +51,7 @@ export function DeckBuilder() {
     const result = validateDeck(deck);
     if (result.success) {
       setErrors([]);
-      setValidationMessage("Leken följer formatreglerna!");
+      setValidationMessage("The deck follows the format rules!");
     } else {
       setValidationMessage(null);
       setErrors(result.error.issues.map((issue) => issue.message));
@@ -64,24 +64,24 @@ export function DeckBuilder() {
     <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl">
       <header className="mb-6 flex items-center justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-white">Deck-check</h2>
+          <h2 className="text-xl font-semibold text-white">Deck Check</h2>
           <p className="text-sm text-slate-400">
-            Bygg en lek och kontrollera att den följer begränsningar per format.
+            Build a deck and ensure it follows the restrictions for each format.
           </p>
         </div>
         <button type="button" onClick={validate}>
-          Validera lek
+          Validate deck
         </button>
       </header>
 
       <div className="space-y-4">
         <div className="flex flex-col gap-4 md:flex-row">
           <div className="flex-1 space-y-2">
-            <label>Leknamn</label>
+            <label>Deck name</label>
             <input
               value={deck.name}
               onChange={(event) => setDeck((prev) => ({ ...prev, name: event.target.value }))}
-              placeholder="Ex. Aether Rush"
+              placeholder="e.g. Aether Rush"
             />
           </div>
           <div className="w-full space-y-2 md:w-48">
@@ -97,10 +97,10 @@ export function DeckBuilder() {
         </div>
 
         <div className="rounded-2xl border border-white/5 bg-slate-950/70 p-4">
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Lägg till kort</h3>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Add card</h3>
           <div className="mt-3 flex flex-col gap-3 lg:flex-row">
             <div className="flex flex-1 flex-col gap-2">
-              <label>Kort</label>
+              <label>Card</label>
               <select value={cardId} onChange={(event) => setCardId(event.target.value)} className="bg-slate-900">
                 {MOCK_LIBRARY.map((card) => (
                   <option key={card.id} value={card.id}>
@@ -110,7 +110,7 @@ export function DeckBuilder() {
               </select>
             </div>
             <div className="w-full space-y-2 lg:w-32">
-              <label>Antal</label>
+              <label>Quantity</label>
               <input
                 type="number"
                 min={1}
@@ -128,7 +128,7 @@ export function DeckBuilder() {
             </div>
             <button type="button" onClick={addCardToDeck} className="lg:w-44">
               <PlusIcon className="mr-2 h-4 w-4" />
-              Lägg till kort
+              Add card
             </button>
           </div>
         </div>
@@ -136,13 +136,13 @@ export function DeckBuilder() {
         <div className="rounded-2xl border border-white/5 bg-slate-950/70 p-4">
           <header className="flex items-center justify-between">
             <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
-              Kortlista ({totalCards} kort)
+              Card list ({totalCards} cards)
             </h3>
-            <span className="text-xs text-slate-500">Max 60 kort</span>
+            <span className="text-xs text-slate-500">Max 60 cards</span>
           </header>
           <ul className="mt-3 space-y-2 text-sm text-slate-200">
             {deck.cards.length === 0 ? (
-              <li className="text-xs text-slate-500">Inga kort har lagts till ännu.</li>
+              <li className="text-xs text-slate-500">No cards have been added yet.</li>
             ) : (
               deck.cards.map((entry) => {
                 const card = MOCK_LIBRARY.find((item) => item.id === entry.cardId);
@@ -151,7 +151,7 @@ export function DeckBuilder() {
                     <div>
                       <p className="font-medium text-slate-100">{card?.name ?? entry.cardId}</p>
                       <p className="text-xs text-slate-500">
-                        {card?.type ?? "Okänd typ"} • {card?.rarity ?? "?"}
+                        {card?.type ?? "Unknown type"} • {card?.rarity ?? "?"}
                       </p>
                     </div>
                     <div className="flex items-center gap-4 text-sm">
@@ -161,7 +161,7 @@ export function DeckBuilder() {
                         onClick={() => removeCard(entry.cardId)}
                         className="text-xs text-rose-300 hover:text-rose-200"
                       >
-                        Ta bort
+                        Remove
                       </button>
                     </div>
                   </li>

--- a/app/components/ExportPanel.tsx
+++ b/app/components/ExportPanel.tsx
@@ -19,10 +19,10 @@ export function ExportPanel({ card }: ExportPanelProps) {
         downloadFile("card.json", jsonPreview);
         break;
       case "png":
-        alert("PNG-export kräver serverrendering av kortlayout. Stub implementerad för prototyp.");
+        alert("PNG export requires server-side rendering of the card layout. Stub implemented for the prototype.");
         break;
       case "pdf":
-        alert("PDF-export bygger på framtida print-and-play generator.");
+        alert("PDF export will rely on a future print-and-play generator.");
         break;
     }
   }
@@ -33,12 +33,12 @@ export function ExportPanel({ card }: ExportPanelProps) {
         <div>
           <h2 className="text-xl font-semibold text-white">Export</h2>
           <p className="text-sm text-slate-400">
-            Ladda ner kortdata i olika format för integration eller utskrift.
+            Download card data in multiple formats for integration or printing.
           </p>
         </div>
         <button type="button" onClick={handleExport}>
           <DocumentArrowDownIcon className="mr-2 h-5 w-5" />
-          Exportera {format.toUpperCase()}
+          Export {format.toUpperCase()}
         </button>
       </header>
 
@@ -52,7 +52,7 @@ export function ExportPanel({ card }: ExportPanelProps) {
           </select>
         </div>
         <div className="flex-1">
-          <label>Förhandsgranskning (JSON)</label>
+          <label>Preview (JSON)</label>
           <pre className="mt-2 h-64 overflow-auto rounded-2xl border border-white/5 bg-slate-950/70 p-4 text-xs text-slate-200">
             {jsonPreview}
           </pre>

--- a/app/components/KeywordManager.tsx
+++ b/app/components/KeywordManager.tsx
@@ -23,9 +23,9 @@ export function KeywordManager() {
   return (
     <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl">
       <header className="mb-6">
-        <h2 className="text-xl font-semibold text-white">Nyckelordshantering</h2>
+        <h2 className="text-xl font-semibold text-white">Keyword Management</h2>
         <p className="text-sm text-slate-400">
-          Centralt register för kortnyckelord. Lägg till egna termer och se vilka kortkategorier de tillhör.
+          Central registry for card keywords. Add your own terms and see which card categories they belong to.
         </p>
       </header>
 
@@ -46,17 +46,17 @@ export function KeywordManager() {
       </div>
 
       <div className="mt-6 rounded-2xl border border-dashed border-white/10 bg-slate-950/60 p-4">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Lägg till eget nyckelord</h3>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Add custom keyword</h3>
         <div className="mt-3 flex flex-col gap-2 sm:flex-row">
           <input
             value={newKeyword}
             onChange={(event) => setNewKeyword(event.target.value)}
-            placeholder="Ex. Chronoshift"
+            placeholder="e.g. Chronoshift"
             className="flex-1"
           />
           <button type="button" onClick={handleAddKeyword} className="sm:w-36">
             <PlusIcon className="mr-2 h-4 w-4" />
-            Lägg till
+            Add keyword
           </button>
         </div>
         {customKeywords.length > 0 ? (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,9 +5,8 @@ import { Inter } from "next/font/google";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "CardForge – Kortspelsbyggare",
-  description:
-    "Bygg, hantera och validera kort för egna kortspel med CardForge."
+  title: "CardForge – Card Game Builder",
+  description: "Build, manage, and validate custom trading cards with CardForge."
 };
 
 export default function RootLayout({
@@ -16,7 +15,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="sv" className="bg-slate-950">
+    <html lang="en" className="bg-slate-950">
       <body className={inter.className}>{children}</body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,11 +9,11 @@ import { KeywordManager } from "@/app/components/KeywordManager";
 import type { CardFormValues } from "@/lib/types";
 
 const initialCard: CardFormValues = {
-  name: "Stjärnvandrare",
+  name: "Starwanderer",
   cost: 4,
   type: "Creature",
   rarity: "Rare",
-  text: "När Stjärnvandrare kommer i spel, dra ett kort.\nBerserk: +2 attack under din tur.",
+  text: "When Starwanderer enters the battlefield, draw a card.\nBerserk: +2 attack during your turn.",
   imageUrl: "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=400&q=80",
   stats: { attack: 3, health: 4, armor: 0 },
   keywords: ["Berserk", "Momentum"],
@@ -26,29 +26,29 @@ export default function HomePage() {
   const [card, setCard] = useState<CardFormValues>(initialCard);
 
   return (
-    <main className="mx-auto max-w-7xl space-y-10 px-4 py-10">
-      <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <main className="mx-auto max-w-7xl space-y-12 px-4 py-10">
+      <header className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <h1 className="text-3xl font-bold text-white sm:text-4xl">CardForge</h1>
           <p className="mt-2 max-w-2xl text-base text-slate-400">
-            Webbaserat verktyg för att skapa, validera och exportera kort till egna kortspel. Designa kort,
-            hantera nyckelord och säkerställ att lekar följer formatregler.
+            Web-based toolkit for creating, validating, and exporting custom trading cards. Design cards, manage
+            keywords, and ensure decks follow format rules.
           </p>
         </div>
         <div className="rounded-3xl border border-primary-500/30 bg-primary-500/10 px-6 py-4 text-sm text-primary-100 shadow-lg">
-          <p className="font-semibold uppercase tracking-wide text-primary-300">Snabbstatus</p>
+          <p className="font-semibold uppercase tracking-wide text-primary-300">At a Glance</p>
           <ul className="mt-2 space-y-1 text-primary-100">
-            <li>✔ Kortvalidering med Zod</li>
-            <li>✔ Nyckelordshantering</li>
-            <li>✔ Deck-check för Standard och Unlimited</li>
-            <li>✔ Export till JSON / PNG / PDF (stub)</li>
+            <li>✔ Card validation with Zod</li>
+            <li>✔ Keyword management</li>
+            <li>✔ Deck checks for Standard &amp; Unlimited</li>
+            <li>✔ Export to JSON / PNG / PDF (stub)</li>
           </ul>
         </div>
       </header>
 
-      <section className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
+      <section className="grid gap-8 lg:grid-cols-[minmax(0,1.45fr)_minmax(0,1fr)] xl:gap-10">
         <CardEditor onChange={setCard} />
-        <div className="flex flex-col items-center justify-start gap-6">
+        <div className="flex w-full flex-col items-center gap-6 lg:items-stretch">
           <CardPreview card={card} />
           <ExportPanel card={card} />
         </div>

--- a/lib/keywords.ts
+++ b/lib/keywords.ts
@@ -15,11 +15,11 @@ export const KEYWORDS = [
 
 export const keywordGroups = [
   {
-    name: "Offensiva",
+    name: "Offensive",
     keywords: ["Charge", "Berserk", "Quickdraw", "Pierce"]
   },
   {
-    name: "Defensiva",
+    name: "Defensive",
     keywords: ["Taunt", "Ward", "Retaliate"]
   },
   {

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -3,12 +3,12 @@ import type { CardFormValues, DeckFormValues } from "./types";
 
 export const cardSchema = z
   .object({
-    name: z.string().min(3, "Namnet måste vara minst 3 tecken."),
+    name: z.string().min(3, "Name must be at least 3 characters."),
     cost: z.number().int().min(0).max(15),
     type: z.enum(["Creature", "Spell", "Artifact", "Hero"]),
     rarity: z.enum(["Common", "Uncommon", "Rare", "Mythic"]),
     text: z.string().max(800).optional().default(""),
-    imageUrl: z.string().url("Ogiltig bildadress."),
+    imageUrl: z.string().url("Invalid image URL."),
     stats: z.object({
       attack: z.number().int().min(0).max(20),
       health: z.number().int().min(1).max(25),
@@ -17,7 +17,7 @@ export const cardSchema = z
     keywords: z.array(z.string()).max(6),
     setId: z.string().min(2),
     expansion: z.string().min(2),
-    version: z.string().regex(/^v\d+\.\d+\.\d+$/, "Version måste följa formatet vX.Y.Z"),
+    version: z.string().regex(/^v\d+\.\d+\.\d+$/, "Version must follow the format vX.Y.Z"),
     createdAt: z.date().optional(),
     updatedAt: z.date().optional()
   })
@@ -25,14 +25,14 @@ export const cardSchema = z
     if (data.type === "Creature" && data.stats.attack === 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "Varelser bör ha minst 1 attack.",
+        message: "Creatures should have at least 1 attack.",
         path: ["stats", "attack"]
       });
     }
     if (data.keywords.includes("Berserk") && data.stats.health < 2) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "Berserk kräver minst 2 liv.",
+        message: "Berserk requires at least 2 health.",
         path: ["stats", "health"]
       });
     }
@@ -52,7 +52,7 @@ export const deckSchema = z
       .max(60)
   })
   .refine((deck) => deck.cards.reduce((sum, card) => sum + card.quantity, 0) >= 40, {
-    message: "Leken måste innehålla minst 40 kort.",
+    message: "The deck must contain at least 40 cards.",
     path: ["cards"]
   })
   .superRefine((deck, ctx) => {
@@ -62,7 +62,7 @@ export const deckSchema = z
         duplicates.forEach((entry, index) => {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: "Standard-format tillåter max 3 kopior av samma kort.",
+            message: "The Standard format allows a maximum of 3 copies of the same card.",
             path: ["cards", index, "quantity"]
           });
         });


### PR DESCRIPTION
## Summary
- translate the home page hero copy and adjust layout spacing for the editor and preview panels
- convert all UI components, API responses, and validation errors from Swedish to English and align keyword group names
- refresh supporting text such as metadata and the README to the new English language baseline

## Testing
- `npm install` *(fails: registry returned 403 for @headlessui/react)*
- `npm run lint` *(fails: next binary missing because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68caf8c42480832ba06cc831b1a16b1a