### PR TITLE
Revamp workspace layout around card preview

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -93,172 +93,222 @@ export function CardEditor({ onChange }: CardEditorProps) {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl">
-        <header className="mb-6 flex items-center justify-between">
-          <div>
-            <h2 className="text-xl font-semibold text-white">Card Editor</h2>
-            <p className="text-sm text-slate-400">
-              Enter card details and get live validation based on the game rules.
-            </p>
-          </div>
-          <button type="button" onClick={handleValidate} className="bg-primary-500 px-4 py-2 text-sm font-semibold">
-            Validate card
-          </button>
-        </header>
+    <section className="workspace-panel space-y-8">
+      <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-white">Card Editor</h2>
+          <p className="text-sm text-slate-400">
+            Tune every attribute and validate the configuration before committing to a print run.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleValidate}
+          className="rounded-full border border-primary-400/40 bg-primary-500/90 px-5 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-primary-500/20 transition hover:bg-primary-400"
+        >
+          Validate card
+        </button>
+      </header>
 
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-          <Field label="Name" error={errors.name}>
-            <input
-              name="name"
-              value={values.name}
-              onChange={(event) => handleChange("name", event.target.value)}
-              placeholder="e.g. Starwanderer"
-            />
-          </Field>
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] xl:gap-8">
+        <div className="space-y-5">
+          <Section title="Card identity" description="Essential details that appear in search results and deck lists.">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <Field label="Name" error={errors.name} className="sm:col-span-2">
+                <input
+                  name="name"
+                  value={values.name}
+                  onChange={(event) => handleChange("name", event.target.value)}
+                  placeholder="e.g. Starwanderer"
+                />
+              </Field>
 
-          <Field label="Cost" error={errors.cost}>
-            <input
-              type="number"
-              name="cost"
-              min={0}
-              max={15}
-              value={values.cost}
-              onChange={(event) => {
-                const value = Number(event.target.value);
-                handleChange("cost", Number.isNaN(value) ? 0 : value);
-              }}
-            />
-          </Field>
+              <Field label="Cost" error={errors.cost}>
+                <input
+                  type="number"
+                  name="cost"
+                  min={0}
+                  max={15}
+                  value={values.cost}
+                  onChange={(event) => {
+                    const value = Number(event.target.value);
+                    handleChange("cost", Number.isNaN(value) ? 0 : value);
+                  }}
+                />
+              </Field>
 
-          <Field label="Card type" error={errors.type}>
-            <select
-              value={values.type}
-              onChange={(event) => handleChange("type", event.target.value as CardFormValues["type"])}
-            >
-              <option value="Creature">Creature</option>
-              <option value="Spell">Spell</option>
-              <option value="Artifact">Artifact</option>
-              <option value="Hero">Hero</option>
-            </select>
-          </Field>
+              <Field label="Card type" error={errors.type}>
+                <select
+                  value={values.type}
+                  onChange={(event) => handleChange("type", event.target.value as CardFormValues["type"])}
+                >
+                  <option value="Creature">Creature</option>
+                  <option value="Spell">Spell</option>
+                  <option value="Artifact">Artifact</option>
+                  <option value="Hero">Hero</option>
+                </select>
+              </Field>
 
-          <Field label="Rarity" error={errors.rarity}>
-            <select
-              value={values.rarity}
-              onChange={(event) => handleChange("rarity", event.target.value as CardFormValues["rarity"])}
-            >
-              <option value="Common">Common</option>
-              <option value="Uncommon">Uncommon</option>
-              <option value="Rare">Rare</option>
-              <option value="Mythic">Mythic</option>
-            </select>
-          </Field>
+              <Field label="Rarity" error={errors.rarity}>
+                <select
+                  value={values.rarity}
+                  onChange={(event) => handleChange("rarity", event.target.value as CardFormValues["rarity"])}
+                >
+                  <option value="Common">Common</option>
+                  <option value="Uncommon">Uncommon</option>
+                  <option value="Rare">Rare</option>
+                  <option value="Mythic">Mythic</option>
+                </select>
+              </Field>
 
-          <Field label="Set ID" error={errors.setId}>
-            <input
-              name="setId"
-              value={values.setId}
-              onChange={(event) => handleChange("setId", event.target.value)}
-            />
-          </Field>
+              <Field label="Set ID" error={errors.setId}>
+                <input
+                  name="setId"
+                  value={values.setId}
+                  onChange={(event) => handleChange("setId", event.target.value)}
+                />
+              </Field>
 
-          <Field label="Expansion" error={errors.expansion}>
-            <input
-              name="expansion"
-              value={values.expansion}
-              onChange={(event) => handleChange("expansion", event.target.value)}
-            />
-          </Field>
+              <Field label="Expansion" error={errors.expansion}>
+                <input
+                  name="expansion"
+                  value={values.expansion}
+                  onChange={(event) => handleChange("expansion", event.target.value)}
+                />
+              </Field>
 
-          <Field label="Version" error={errors.version}>
-            <input
-              name="version"
-              value={values.version}
-              onChange={(event) => handleChange("version", event.target.value)}
-            />
-          </Field>
+              <Field label="Version" error={errors.version}>
+                <input
+                  name="version"
+                  value={values.version}
+                  onChange={(event) => handleChange("version", event.target.value)}
+                />
+              </Field>
+            </div>
+          </Section>
 
-          <Field label="Image URL" error={errors.imageUrl}>
-            <input
-              name="imageUrl"
-              value={values.imageUrl}
-              onChange={(event) => handleChange("imageUrl", event.target.value)}
-              placeholder="https://"
-            />
-          </Field>
+          <Section title="Artwork & lore" description="Control how the card presents itself visually and narratively.">
+            <div className="grid gap-4">
+              <Field label="Image URL" error={errors.imageUrl}>
+                <input
+                  name="imageUrl"
+                  value={values.imageUrl}
+                  onChange={(event) => handleChange("imageUrl", event.target.value)}
+                  placeholder="https://"
+                />
+              </Field>
 
-          <Field label="Attack" error={errors["stats.attack"]}>
-            <input
-              type="number"
-              min={0}
-              max={20}
-              value={values.stats.attack}
-              onChange={(event) => handleStatChange("attack", Number(event.target.value))}
-            />
-          </Field>
-
-          <Field label="Health" error={errors["stats.health"]}>
-            <input
-              type="number"
-              min={1}
-              max={25}
-              value={values.stats.health}
-              onChange={(event) => handleStatChange("health", Number(event.target.value))}
-            />
-          </Field>
-
-          <Field label="Armor" error={errors["stats.armor"]}>
-            <input
-              type="number"
-              min={0}
-              max={10}
-              value={values.stats.armor ?? 0}
-              onChange={(event) => handleStatChange("armor", Number(event.target.value))}
-            />
-          </Field>
+              <Field label="Rules text" error={errors.text}>
+                <textarea
+                  rows={5}
+                  value={values.text}
+                  onChange={(event) => handleChange("text", event.target.value)}
+                  placeholder={"Describe the card effect and any special rules."}
+                />
+              </Field>
+            </div>
+          </Section>
         </div>
 
-        <Field label="Rules text" error={errors.text}>
-          <textarea
-            rows={4}
-            value={values.text}
-            onChange={(event) => handleChange("text", event.target.value)}
-            placeholder={"Describe the card effect and any special rules."}
-          />
-        </Field>
+        <div className="space-y-5">
+          <Section title="Combat profile" description="Balance the numbers to match the intended power curve.">
+            <div className="grid gap-4 sm:grid-cols-3">
+              <Field label="Attack" error={errors["stats.attack"]}>
+                <input
+                  type="number"
+                  min={0}
+                  max={20}
+                  value={values.stats.attack}
+                  onChange={(event) => handleStatChange("attack", Number(event.target.value))}
+                />
+              </Field>
 
-        <div className="space-y-2">
-          <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Keywords</label>
-          <KeywordSelector
-            selectedKeywords={values.keywords}
-            onAddKeyword={addKeyword}
-            onRemoveKeyword={removeKeyword}
-            query={keywordQuery}
-            onQueryChange={setKeywordQuery}
-            suggestions={filteredKeywords}
-          />
-          {errors.keywords ? <p className="text-sm text-rose-400">{errors.keywords}</p> : null}
+              <Field label="Health" error={errors["stats.health"]}>
+                <input
+                  type="number"
+                  min={1}
+                  max={25}
+                  value={values.stats.health}
+                  onChange={(event) => handleStatChange("health", Number(event.target.value))}
+                />
+              </Field>
+
+              <Field label="Armor" error={errors["stats.armor"]}>
+                <input
+                  type="number"
+                  min={0}
+                  max={10}
+                  value={values.stats.armor ?? 0}
+                  onChange={(event) => handleStatChange("armor", Number(event.target.value))}
+                />
+              </Field>
+            </div>
+          </Section>
+
+          <Section
+            title="Keywords"
+            description="Attach mechanics and ability words to surface core interactions."
+            variant="muted"
+          >
+            <KeywordSelector
+              selectedKeywords={values.keywords}
+              onAddKeyword={addKeyword}
+              onRemoveKeyword={removeKeyword}
+              query={keywordQuery}
+              onQueryChange={setKeywordQuery}
+              suggestions={filteredKeywords}
+            />
+            {errors.keywords ? <p className="text-sm text-rose-400">{errors.keywords}</p> : null}
+          </Section>
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 
 function Field({
   label,
   error,
-  children
+  children,
+  className
 }: {
   label: string;
   error?: string;
   children: ReactNode;
+  className?: string;
 }) {
   return (
-    <div className="space-y-2">
+    <div className={clsx("space-y-2", className)}>
       <label>{label}</label>
       {children}
       {error ? <p className="text-sm text-rose-400">{error}</p> : null}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+  variant = "default"
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+  variant?: "default" | "muted";
+}) {
+  return (
+    <div
+      className={clsx(
+        "workspace-panel__section space-y-4",
+        variant === "muted" && "workspace-panel__section--muted"
+      )}
+    >
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-200">{title}</h3>
+        <p className="text-xs text-slate-500">{description}</p>
+      </div>
+      {children}
     </div>
   );
 }
@@ -281,7 +331,7 @@ function KeywordSelector({
   onRemoveKeyword
 }: KeywordSelectorProps) {
   return (
-    <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-slate-950/70 p-4">
+    <div className="flex flex-col gap-4">
       <Combobox value={query} onChange={onAddKeyword}>
         <div className="relative">
           <div className="relative w-full cursor-default overflow-hidden rounded-lg text-left shadow-md focus:outline-none">

--- a/app/components/DeckBuilder.tsx
+++ b/app/components/DeckBuilder.tsx
@@ -61,31 +61,37 @@ export function DeckBuilder() {
   const totalCards = deck.cards.reduce((sum, item) => sum + item.quantity, 0);
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl">
-      <header className="mb-6 flex items-center justify-between">
+    <section className="workspace-panel space-y-6">
+      <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-white">Deck Check</h2>
+          <h2 className="text-2xl font-semibold text-white">Deck Check</h2>
           <p className="text-sm text-slate-400">
-            Build a deck and ensure it follows the restrictions for each format.
+            Assemble a list and verify format constraints before locking a tournament build.
           </p>
         </div>
-        <button type="button" onClick={validate}>
+        <button type="button" onClick={validate} className="rounded-full border border-primary-400/40 bg-primary-500/90 px-5 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-primary-500/20 transition hover:bg-primary-400">
           Validate deck
         </button>
       </header>
 
-      <div className="space-y-4">
-        <div className="flex flex-col gap-4 md:flex-row">
-          <div className="flex-1 space-y-2">
-            <label>Deck name</label>
+      <div className="space-y-5">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_220px]">
+          <div className="workspace-panel__section space-y-3">
+            <div className="space-y-1">
+              <label>Deck name</label>
+              <p className="text-xs text-slate-500">Displayed on exports and deck registries.</p>
+            </div>
             <input
               value={deck.name}
               onChange={(event) => setDeck((prev) => ({ ...prev, name: event.target.value }))}
               placeholder="e.g. Aether Rush"
             />
           </div>
-          <div className="w-full space-y-2 md:w-48">
-            <label>Format</label>
+          <div className="workspace-panel__section space-y-3">
+            <div className="space-y-1">
+              <label>Format</label>
+              <p className="text-xs text-slate-500">Applies legality checks to the card pool.</p>
+            </div>
             <select
               value={deck.format}
               onChange={(event) => setDeck((prev) => ({ ...prev, format: event.target.value as DeckFormValues["format"] }))}
@@ -96,9 +102,12 @@ export function DeckBuilder() {
           </div>
         </div>
 
-        <div className="rounded-2xl border border-white/5 bg-slate-950/70 p-4">
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Add card</h3>
-          <div className="mt-3 flex flex-col gap-3 lg:flex-row">
+        <div className="workspace-panel__section space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-200">Add card</h3>
+            <span className="text-[11px] uppercase text-slate-500">Library size: {MOCK_LIBRARY.length}</span>
+          </div>
+          <div className="flex flex-col gap-3 lg:flex-row">
             <div className="flex flex-1 flex-col gap-2">
               <label>Card</label>
               <select value={cardId} onChange={(event) => setCardId(event.target.value)} className="bg-slate-900">
@@ -126,21 +135,21 @@ export function DeckBuilder() {
                 }}
               />
             </div>
-            <button type="button" onClick={addCardToDeck} className="lg:w-44">
+            <button type="button" onClick={addCardToDeck} className="lg:w-40">
               <PlusIcon className="mr-2 h-4 w-4" />
               Add card
             </button>
           </div>
         </div>
 
-        <div className="rounded-2xl border border-white/5 bg-slate-950/70 p-4">
+        <div className="workspace-panel__section space-y-4">
           <header className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-200">
               Card list ({totalCards} cards)
             </h3>
             <span className="text-xs text-slate-500">Max 60 cards</span>
           </header>
-          <ul className="mt-3 space-y-2 text-sm text-slate-200">
+          <ul className="space-y-2 text-sm text-slate-200">
             {deck.cards.length === 0 ? (
               <li className="text-xs text-slate-500">No cards have been added yet.</li>
             ) : (
@@ -159,7 +168,7 @@ export function DeckBuilder() {
                       <button
                         type="button"
                         onClick={() => removeCard(entry.cardId)}
-                        className="text-xs text-rose-300 hover:text-rose-200"
+                        className="text-xs text-rose-300 transition hover:text-rose-200"
                       >
                         Remove
                       </button>

--- a/app/components/ExportPanel.tsx
+++ b/app/components/ExportPanel.tsx
@@ -28,27 +28,30 @@ export function ExportPanel({ card }: ExportPanelProps) {
   }
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl">
-      <header className="mb-6 flex items-center justify-between">
-        <div>
-          <h2 className="text-xl font-semibold text-white">Export</h2>
+    <section className="workspace-panel space-y-6">
+      <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold text-white">Export Toolkit</h2>
           <p className="text-sm text-slate-400">
-            Download card data in multiple formats for integration or printing.
+            Package the current card as structured data or production-ready assets.
           </p>
         </div>
         <button
           type="button"
           onClick={handleExport}
-          className="inline-flex items-center gap-2 rounded-full bg-primary-500 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-primary-500/30 transition hover:bg-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-300 focus:ring-offset-2 focus:ring-offset-slate-900"
+          className="inline-flex items-center gap-2 rounded-full border border-primary-400/40 bg-primary-500/90 px-5 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-primary-500/25 transition hover:bg-primary-400"
         >
           <DocumentArrowDownIcon className="h-5 w-5" />
           Export {format.toUpperCase()}
         </button>
       </header>
 
-      <div className="flex flex-col gap-4 lg:flex-row">
-        <div className="flex w-full flex-col gap-2 lg:w-40">
-          <label className="text-sm font-medium text-slate-300">Format</label>
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,180px)_1fr] lg:items-start">
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Format</label>
+            <p className="text-xs text-slate-500">Choose the pipeline destination.</p>
+          </div>
           <select
             value={format}
             onChange={(event) => setFormat(event.target.value as typeof format)}
@@ -59,9 +62,12 @@ export function ExportPanel({ card }: ExportPanelProps) {
             <option value="pdf">PDF</option>
           </select>
         </div>
-        <div className="flex-1">
-          <label className="text-sm font-medium text-slate-300">Preview (JSON)</label>
-          <pre className="mt-2 h-64 w-full overflow-auto rounded-2xl border border-white/5 bg-slate-950/70 p-4 font-mono text-xs text-slate-200">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Preview</label>
+            <span className="text-[11px] uppercase text-slate-500">Read-only</span>
+          </div>
+          <pre className="h-64 w-full overflow-auto rounded-2xl border border-white/5 bg-slate-950/70 p-4 font-mono text-xs text-slate-200">
             {jsonPreview}
           </pre>
         </div>

--- a/app/components/KeywordManager.tsx
+++ b/app/components/KeywordManager.tsx
@@ -21,23 +21,26 @@ export function KeywordManager() {
   }
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-xl">
-      <header className="mb-6">
-        <h2 className="text-xl font-semibold text-white">Keyword Management</h2>
+    <section className="workspace-panel space-y-6">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-white">Keyword Management</h2>
         <p className="text-sm text-slate-400">
-          Central registry for card keywords. Add your own terms and see which card categories they belong to.
+          Curate the shared vocabulary that powers rules text, search filters, and deck validation.
         </p>
       </header>
 
       <div className="grid gap-4 md:grid-cols-2">
         {keywordGroups.map((group) => (
-          <article key={group.name} className="rounded-2xl border border-white/5 bg-slate-950/70 p-4">
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-primary-300">{group.name}</h3>
-            <ul className="mt-2 space-y-2 text-sm text-slate-200">
+          <article key={group.name} className="workspace-panel__section space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-primary-300">{group.name}</h3>
+              <span className="text-[11px] uppercase text-slate-500">{group.keywords.length} keywords</span>
+            </div>
+            <ul className="space-y-2 text-sm text-slate-200">
               {group.keywords.map((keyword) => (
                 <li key={keyword} className="flex items-center justify-between">
                   <span>{keyword}</span>
-                  <span className="text-xs text-slate-500">Core</span>
+                  <span className="text-xs text-slate-500">{group.name}</span>
                 </li>
               ))}
             </ul>
@@ -45,22 +48,25 @@ export function KeywordManager() {
         ))}
       </div>
 
-      <div className="mt-6 rounded-2xl border border-dashed border-white/10 bg-slate-950/60 p-4">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Add custom keyword</h3>
-        <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+      <div className="workspace-panel__section workspace-panel__section--muted space-y-4">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Add custom keyword</h3>
+          <p className="text-xs text-slate-500">Extend the keyword pool with new mechanics or localized terminology.</p>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
           <input
             value={newKeyword}
             onChange={(event) => setNewKeyword(event.target.value)}
             placeholder="e.g. Chronoshift"
             className="flex-1"
           />
-          <button type="button" onClick={handleAddKeyword} className="sm:w-36">
+          <button type="button" onClick={handleAddKeyword} className="sm:w-40">
             <PlusIcon className="mr-2 h-4 w-4" />
             Add keyword
           </button>
         </div>
         {customKeywords.length > 0 ? (
-          <ul className="mt-3 flex flex-wrap gap-2 text-xs text-primary-200">
+          <ul className="flex flex-wrap gap-2 text-xs text-primary-200">
             {customKeywords.map((keyword) => (
               <li key={keyword} className="rounded-full bg-primary-500/20 px-3 py-1">
                 {keyword}

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,11 +3,15 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: light;
+  color-scheme: dark;
 }
 
 body {
-  @apply bg-slate-950 text-slate-100 min-h-screen;
+  @apply relative min-h-screen bg-slate-950 text-slate-100 antialiased;
+  background: radial-gradient(circle at top left, rgba(67, 56, 202, 0.4), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.25), transparent 60%),
+    linear-gradient(160deg, rgba(2, 6, 23, 0.95), rgba(15, 23, 42, 0.9));
+  overflow-x: hidden;
 }
 
 a {
@@ -24,6 +28,37 @@ label {
 
 button {
   @apply inline-flex items-center justify-center rounded-md bg-primary-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-400 disabled:opacity-60 disabled:cursor-not-allowed;
+}
+
+.workspace-shell {
+  @apply relative isolate mx-auto max-w-[1440px] px-6 py-10 sm:px-8 lg:px-12;
+}
+
+.workspace-shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: min(70%, 780px);
+  height: 70%;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.2), transparent 60%);
+  filter: blur(80px);
+  opacity: 0.6;
+  z-index: -1;
+}
+
+.workspace-panel {
+  @apply rounded-3xl border border-white/10 bg-slate-900/70 p-6 shadow-[0_32px_60px_-45px_rgba(15,23,42,0.9)];
+  backdrop-filter: blur(18px);
+}
+
+.workspace-panel__section {
+  @apply rounded-2xl border border-white/5 bg-slate-950/60 p-5 shadow-inner shadow-black/20;
+}
+
+.workspace-panel__section--muted {
+  @apply border-dashed border-white/10 bg-slate-950/40;
 }
 
 .card-surface {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,36 +26,50 @@ export default function HomePage() {
   const [card, setCard] = useState<CardFormValues>(initialCard);
 
   return (
-    <main className="mx-auto max-w-7xl space-y-12 px-4 py-10">
-      <header className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-white sm:text-4xl">CardForge</h1>
-          <p className="mt-2 max-w-2xl text-base text-slate-400">
-            Web-based toolkit for creating, validating, and exporting custom trading cards. Design cards, manage
-            keywords, and ensure decks follow format rules.
+    <main className="workspace-shell">
+      <header className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-3">
+          <p className="text-sm uppercase tracking-[0.2em] text-primary-300">Card design control room</p>
+          <h1 className="text-4xl font-semibold text-white sm:text-5xl">CardForge</h1>
+          <p className="max-w-2xl text-base text-slate-300">
+            Craft competitive-ready cards with instant validation, manage mechanics from a shared keyword registry, and
+            keep decks compliant with format rules before they ever hit the table.
           </p>
         </div>
-        <div className="rounded-3xl border border-primary-500/30 bg-primary-500/10 px-6 py-4 text-sm text-primary-100 shadow-lg">
-          <p className="font-semibold uppercase tracking-wide text-primary-300">At a Glance</p>
-          <ul className="mt-2 space-y-1 text-primary-100">
-            <li>✔ Card validation with Zod</li>
-            <li>✔ Keyword management</li>
-            <li>✔ Deck checks for Standard &amp; Unlimited</li>
-            <li>✔ Export to JSON / PNG / PDF (stub)</li>
+        <aside className="flex w-full max-w-sm flex-col gap-4 rounded-3xl border border-primary-500/30 bg-slate-900/80 p-5 text-sm text-primary-100 shadow-[0_20px_40px_-30px_rgba(56,189,248,0.35)] lg:w-auto">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary-200">Mission Checklist</p>
+          <ul className="space-y-2 text-primary-100">
+            <li className="flex items-center gap-3">
+              <span className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
+              Card validation powered by Zod schemas
+            </li>
+            <li className="flex items-center gap-3">
+              <span className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
+              Centralized keyword management &amp; curation
+            </li>
+            <li className="flex items-center gap-3">
+              <span className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
+              Deck legality checks for Standard &amp; Unlimited
+            </li>
+            <li className="flex items-center gap-3">
+              <span className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+              Export flows for JSON / PNG / PDF (prototype)
+            </li>
           </ul>
-        </div>
+        </aside>
       </header>
-      <section className="flex flex-col gap-8 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)] xl:gap-12">
-        <div className="order-2 flex flex-col gap-8 lg:order-1">
+
+      <section className="mt-12 grid gap-8 xl:grid-cols-[minmax(18rem,24rem)_minmax(21rem,28rem)_minmax(20rem,1fr)] xl:gap-10 2xl:gap-12">
+        <div className="flex flex-col gap-8">
           <CardEditor onChange={setCard} />
-          <ExportPanel card={card} />
-          <div className="grid gap-6 lg:grid-cols-2">
-            <KeywordManager />
-            <DeckBuilder />
-          </div>
         </div>
-        <div className="order-1 flex items-start justify-center lg:order-2 lg:sticky lg:top-24">
+        <div className="flex justify-center xl:sticky xl:top-24">
           <CardPreview card={card} />
+        </div>
+        <div className="flex flex-col gap-8">
+          <ExportPanel card={card} />
+          <KeywordManager />
+          <DeckBuilder />
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- redesign the landing workspace into a three-column layout with a hero checklist header and sticky card preview
- introduce reusable workspace styling utilities for the background, shell, and panel sections
- restyle the editor, export, keyword, and deck panels to fit the new layout and improve copy and structure

## Testing
- npm run lint *(fails: `next` binary missing in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cb02d9e208832ba36c70895ec338a3