### PR TITLE
Redesign CardForge workspace layout

### DIFF
--- a/app/components/CardPreview.tsx
+++ b/app/components/CardPreview.tsx
@@ -10,7 +10,7 @@ interface CardPreviewProps {
 
 export function CardPreview({ card }: CardPreviewProps) {
   return (
-    <div className="card-surface relative mx-auto flex h-[480px] w-[320px] flex-col overflow-hidden rounded-3xl border border-white/10 p-4 text-slate-100 shadow-2xl sm:h-[520px] sm:w-[360px] lg:h-[600px] lg:w-[420px]">
+    <div className="card-surface relative mx-auto flex w-full max-w-[420px] flex-col overflow-hidden rounded-3xl border border-white/10 p-4 text-slate-100 shadow-2xl min-h-[520px]">
       <header className="card-header relative flex items-center justify-between rounded-2xl px-4 py-2 text-slate-50 shadow-lg">
         <span className="text-lg font-semibold uppercase tracking-wide">
           {card.name || "New card"}
@@ -20,13 +20,13 @@ export function CardPreview({ card }: CardPreviewProps) {
         </span>
       </header>
 
-      <div className="mt-4 flex-1 overflow-hidden rounded-2xl border border-white/10 bg-slate-900/70">
+      <div className="mt-4 aspect-[3/4] overflow-hidden rounded-2xl border border-white/10 bg-slate-900/70">
         {card.imageUrl ? (
           <Image
             src={card.imageUrl}
             alt={card.name}
-            width={288}
-            height={200}
+            width={600}
+            height={800}
             className="h-full w-full object-cover"
           />
         ) : (
@@ -57,7 +57,7 @@ export function CardPreview({ card }: CardPreviewProps) {
         </div>
       </div>
 
-      <footer className="mt-3 flex items-center justify-between rounded-2xl bg-slate-900/70 px-4 py-2">
+      <footer className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-slate-900/70 px-4 py-2">
         <div className="flex items-center gap-3 text-slate-200">
           <StatBadge label="ATK" value={card.stats.attack} />
           <StatBadge label="HP" value={card.stats.health} />

--- a/app/globals.css
+++ b/app/globals.css
@@ -31,7 +31,7 @@ button {
 }
 
 .workspace-shell {
-  @apply relative isolate mx-auto max-w-[1440px] px-6 py-10 sm:px-8 lg:px-12;
+  @apply relative isolate mx-auto max-w-7xl px-6 py-12 sm:px-8 lg:px-12;
 }
 
 .workspace-shell::before {
@@ -39,13 +39,38 @@ button {
   position: absolute;
   inset: 0;
   margin: auto;
-  width: min(70%, 780px);
-  height: 70%;
+  width: min(65%, 760px);
+  height: 65%;
   border-radius: 9999px;
   background: radial-gradient(circle, rgba(59, 130, 246, 0.2), transparent 60%);
   filter: blur(80px);
   opacity: 0.6;
   z-index: -1;
+}
+
+.dashboard-header {
+  @apply flex flex-col gap-8 rounded-3xl border border-white/10 bg-slate-900/70 p-6 shadow-[0_30px_60px_-45px_rgba(15,23,42,0.9)] backdrop-blur;
+  @apply lg:flex-row lg:items-center lg:justify-between lg:gap-12;
+}
+
+.dashboard-metrics {
+  @apply grid w-full gap-4 sm:grid-cols-2 lg:max-w-xl lg:grid-cols-2 xl:max-w-none xl:grid-cols-4;
+}
+
+.dashboard-metrics div {
+  @apply flex flex-col gap-1 rounded-2xl border border-white/5 bg-slate-950/60 p-4 text-left shadow-inner shadow-black/30;
+}
+
+.dashboard-metrics dt {
+  @apply text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-500;
+}
+
+.dashboard-metrics dd {
+  @apply text-sm font-medium text-slate-100;
+}
+
+.dashboard-grid {
+  @apply grid gap-8 items-start xl:grid-cols-[minmax(0,1.7fr)_minmax(0,1fr)] xl:gap-10 2xl:gap-12;
 }
 
 .workspace-panel {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,51 +27,50 @@ export default function HomePage() {
 
   return (
     <main className="workspace-shell">
-      <header className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
-        <div className="space-y-3">
-          <p className="text-sm uppercase tracking-[0.2em] text-primary-300">Card design control room</p>
-          <h1 className="text-4xl font-semibold text-white sm:text-5xl">CardForge</h1>
-          <p className="max-w-2xl text-base text-slate-300">
-            Craft competitive-ready cards with instant validation, manage mechanics from a shared keyword registry, and
-            keep decks compliant with format rules before they ever hit the table.
-          </p>
-        </div>
-        <aside className="flex w-full max-w-sm flex-col gap-4 rounded-3xl border border-primary-500/30 bg-slate-900/80 p-5 text-sm text-primary-100 shadow-[0_20px_40px_-30px_rgba(56,189,248,0.35)] lg:w-auto">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-primary-200">Mission Checklist</p>
-          <ul className="space-y-2 text-primary-100">
-            <li className="flex items-center gap-3">
-              <span className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
-              Card validation powered by Zod schemas
-            </li>
-            <li className="flex items-center gap-3">
-              <span className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
-              Centralized keyword management &amp; curation
-            </li>
-            <li className="flex items-center gap-3">
-              <span className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
-              Deck legality checks for Standard &amp; Unlimited
-            </li>
-            <li className="flex items-center gap-3">
-              <span className="h-2.5 w-2.5 rounded-full bg-amber-400" />
-              Export flows for JSON / PNG / PDF (prototype)
-            </li>
-          </ul>
-        </aside>
-      </header>
+      <div className="space-y-10">
+        <header className="dashboard-header">
+          <div className="space-y-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-primary-200">Design &amp; Validation Hub</p>
+            <div className="space-y-2">
+              <h1 className="text-4xl font-semibold text-white sm:text-5xl">CardForge</h1>
+              <p className="max-w-3xl text-base text-slate-300">
+                Det kompletta gränssnittet för att bygga kort, kontrollera lekar och hålla ordning på nyckelord – allt i
+                en arbetsvy anpassad för både prototypande och turneringsförberedelser.
+              </p>
+            </div>
+          </div>
+          <dl className="dashboard-metrics">
+            <div>
+              <dt>Validator</dt>
+              <dd>Zod-powered schemas</dd>
+            </div>
+            <div>
+              <dt>Nyckelord</dt>
+              <dd>Delat bibliotek</dd>
+            </div>
+            <div>
+              <dt>Formatstöd</dt>
+              <dd>Standard &amp; Unlimited</dd>
+            </div>
+            <div>
+              <dt>Export</dt>
+              <dd>JSON · PNG · PDF</dd>
+            </div>
+          </dl>
+        </header>
 
-      <section className="mt-12 grid gap-8 xl:grid-cols-[minmax(18rem,24rem)_minmax(21rem,28rem)_minmax(20rem,1fr)] xl:gap-10 2xl:gap-12">
-        <div className="flex flex-col gap-8">
-          <CardEditor onChange={setCard} />
-        </div>
-        <div className="flex justify-center xl:sticky xl:top-24">
-          <CardPreview card={card} />
-        </div>
-        <div className="flex flex-col gap-8">
-          <ExportPanel card={card} />
-          <KeywordManager />
-          <DeckBuilder />
-        </div>
-      </section>
+        <section className="dashboard-grid">
+          <div className="space-y-8">
+            <CardEditor onChange={setCard} />
+            <DeckBuilder />
+          </div>
+          <div className="space-y-8">
+            <CardPreview card={card} />
+            <ExportPanel card={card} />
+            <KeywordManager />
+          </div>
+        </section>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- rebuild the CardForge landing workflow into a two-column dashboard that gives the editor and deck tools room to breathe
- restyle the hero section with compact status tiles to surface validation, keyword, format, and export capabilities
- resize the card preview so it scales with the available column width while keeping artwork and metadata tidy
- extend the global styles with dashboard layout helpers for the new structure

## Testing
- npm install *(fails: npm registry access is blocked in the environment)*
- npm run lint *(fails: Next.js binaries are unavailable without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cb05a77aec832b92ca4a7a5341307b