### PR TITLE
Revamp workspace layout to match wireframe

### DIFF
--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -7,6 +7,7 @@ import { KEYWORDS } from "@/lib/keywords";
 import type { CardFormValues } from "@/lib/types";
 import { validateCard } from "@/lib/validators";
 import clsx from "classnames";
+import { Select } from "@/app/components/ui/Select";
 
 const defaultValues: CardFormValues = {
   name: "",
@@ -93,11 +94,11 @@ export function CardEditor({ onChange }: CardEditorProps) {
   }
 
   return (
-    <section className="workspace-panel space-y-8">
+    <section className="workspace-panel space-y-8 text-slate-900 dark:text-slate-100">
       <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <h2 className="text-2xl font-semibold text-slate-900">Card Editor</h2>
-          <p className="text-sm text-slate-600">
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Card Editor</h2>
+          <p className="text-sm text-slate-600 dark:text-slate-400">
             Tune every attribute and validate the configuration before committing to a print run.
           </p>
         </div>
@@ -138,7 +139,7 @@ export function CardEditor({ onChange }: CardEditorProps) {
               </Field>
 
               <Field label="Card type" error={errors.type}>
-                <select
+                <Select
                   value={values.type}
                   onChange={(event) => handleChange("type", event.target.value as CardFormValues["type"])}
                 >
@@ -146,11 +147,11 @@ export function CardEditor({ onChange }: CardEditorProps) {
                   <option value="Spell">Spell</option>
                   <option value="Artifact">Artifact</option>
                   <option value="Hero">Hero</option>
-                </select>
+                </Select>
               </Field>
 
               <Field label="Rarity" error={errors.rarity}>
-                <select
+                <Select
                   value={values.rarity}
                   onChange={(event) => handleChange("rarity", event.target.value as CardFormValues["rarity"])}
                 >
@@ -158,7 +159,7 @@ export function CardEditor({ onChange }: CardEditorProps) {
                   <option value="Uncommon">Uncommon</option>
                   <option value="Rare">Rare</option>
                   <option value="Mythic">Mythic</option>
-                </select>
+                </Select>
               </Field>
 
               <Field label="Set ID" error={errors.setId}>
@@ -280,7 +281,7 @@ function Field({
   return (
     <div className={clsx("space-y-2", className)}>
       <div className="flex items-center justify-between">
-        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</label>
+        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">{label}</label>
         {error ? <span className="text-xs text-rose-500">{error}</span> : null}
       </div>
       {children}
@@ -307,8 +308,8 @@ function Section({
       )}
     >
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700">{title}</h3>
-        <p className="text-xs text-slate-500">{description}</p>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-200">{title}</h3>
+        <p className="text-xs text-slate-500 dark:text-slate-400">{description}</p>
       </div>
       {children}
     </div>
@@ -336,19 +337,19 @@ function KeywordSelector({
     <div className="flex flex-col gap-4">
       <Combobox value={query} onChange={onAddKeyword}>
         <div className="relative">
-          <div className="relative w-full cursor-default overflow-hidden rounded-xl border border-slate-300 bg-white text-left shadow-sm focus-within:border-primary-300 focus-within:ring-2 focus-within:ring-primary-100">
+          <div className="relative w-full cursor-default overflow-hidden rounded-xl border border-slate-300 bg-white text-left shadow-sm focus-within:border-primary-300 focus-within:ring-2 focus-within:ring-primary-100 dark:border-slate-700 dark:bg-slate-900 dark:focus-within:border-primary-500 dark:focus-within:ring-primary-600/40">
             <Combobox.Input
-              className="w-full bg-transparent py-2 pl-3 pr-10 text-sm leading-5 text-slate-900 focus:outline-none"
+              className="w-full bg-transparent py-2 pl-3 pr-10 text-sm leading-5 text-slate-900 focus:outline-none dark:text-slate-100"
               displayValue={() => query}
               onChange={(event) => onQueryChange(event.target.value)}
               placeholder="Search keywords"
             />
-            <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2 text-slate-400">
+            <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2 text-slate-400 dark:text-slate-500">
               <ChevronUpDownIcon className="h-5 w-5" aria-hidden="true" />
             </Combobox.Button>
           </div>
           {suggestions.length > 0 ? (
-            <Combobox.Options className="absolute z-10 mt-1 max-h-40 w-full overflow-auto rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg">
+            <Combobox.Options className="absolute z-10 mt-1 max-h-40 w-full overflow-auto rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg dark:border-slate-700 dark:bg-slate-900">
               {suggestions.map((keyword) => (
                 <Combobox.Option
                   key={keyword}
@@ -356,7 +357,9 @@ function KeywordSelector({
                   className={({ active }) =>
                     clsx(
                       "relative cursor-default select-none py-2 pl-8 pr-4",
-                      active ? "bg-primary-50 text-primary-600" : "text-slate-700"
+                      active
+                        ? "bg-primary-50 text-primary-600 dark:bg-primary-500/20 dark:text-primary-200"
+                        : "text-slate-700 dark:text-slate-200"
                     )
                   }
                 >
@@ -364,7 +367,7 @@ function KeywordSelector({
                     <>
                       <span className="block truncate">{keyword}</span>
                       {active ? (
-                        <span className="absolute inset-y-0 left-0 flex items-center pl-2 text-primary-500">
+                        <span className="absolute inset-y-0 left-0 flex items-center pl-2 text-primary-500 dark:text-primary-200">
                           <CheckIcon className="h-5 w-5" aria-hidden="true" />
                         </span>
                       ) : null}
@@ -381,13 +384,13 @@ function KeywordSelector({
         {selectedKeywords.map((keyword) => (
           <span
             key={keyword}
-            className="inline-flex items-center gap-2 rounded-full bg-primary-100 px-3 py-1 text-xs font-medium text-primary-700"
+            className="inline-flex items-center gap-2 rounded-full bg-primary-100 px-3 py-1 text-xs font-medium text-primary-700 dark:bg-primary-500/20 dark:text-primary-200"
           >
             {keyword}
             <button
               type="button"
               onClick={() => onRemoveKeyword(keyword)}
-              className="rounded-full bg-primary-200/80 p-0.5 text-primary-700 hover:bg-primary-300"
+              className="rounded-full bg-primary-200/80 p-0.5 text-primary-700 transition hover:bg-primary-300 dark:bg-primary-500/20 dark:text-primary-100 dark:hover:bg-primary-500/30"
             >
               <XMarkIcon className="h-3 w-3" />
             </button>
@@ -396,7 +399,7 @@ function KeywordSelector({
         <button
           type="button"
           onClick={() => (query ? onAddKeyword(query) : null)}
-          className="inline-flex items-center gap-1 text-xs font-medium text-primary-600"
+          className="inline-flex items-center gap-1 text-xs font-medium text-primary-600 dark:text-primary-300"
         >
           <PlusIcon className="h-4 w-4" />
           Add keyword

--- a/app/components/CardEditor.tsx
+++ b/app/components/CardEditor.tsx
@@ -96,15 +96,15 @@ export function CardEditor({ onChange }: CardEditorProps) {
     <section className="workspace-panel space-y-8">
       <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <h2 className="text-2xl font-semibold text-white">Card Editor</h2>
-          <p className="text-sm text-slate-400">
+          <h2 className="text-2xl font-semibold text-slate-900">Card Editor</h2>
+          <p className="text-sm text-slate-600">
             Tune every attribute and validate the configuration before committing to a print run.
           </p>
         </div>
         <button
           type="button"
           onClick={handleValidate}
-          className="rounded-full border border-primary-400/40 bg-primary-500/90 px-5 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-primary-500/20 transition hover:bg-primary-400"
+          className="rounded-full border border-primary-200 bg-primary-500 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-400"
         >
           Validate card
         </button>
@@ -258,7 +258,7 @@ export function CardEditor({ onChange }: CardEditorProps) {
               onQueryChange={setKeywordQuery}
               suggestions={filteredKeywords}
             />
-            {errors.keywords ? <p className="text-sm text-rose-400">{errors.keywords}</p> : null}
+            {errors.keywords ? <p className="text-sm text-rose-500">{errors.keywords}</p> : null}
           </Section>
         </div>
       </div>
@@ -279,9 +279,11 @@ function Field({
 }) {
   return (
     <div className={clsx("space-y-2", className)}>
-      <label>{label}</label>
+      <div className="flex items-center justify-between">
+        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</label>
+        {error ? <span className="text-xs text-rose-500">{error}</span> : null}
+      </div>
       {children}
-      {error ? <p className="text-sm text-rose-400">{error}</p> : null}
     </div>
   );
 }
@@ -305,7 +307,7 @@ function Section({
       )}
     >
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-200">{title}</h3>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700">{title}</h3>
         <p className="text-xs text-slate-500">{description}</p>
       </div>
       {children}
@@ -334,9 +336,9 @@ function KeywordSelector({
     <div className="flex flex-col gap-4">
       <Combobox value={query} onChange={onAddKeyword}>
         <div className="relative">
-          <div className="relative w-full cursor-default overflow-hidden rounded-lg text-left shadow-md focus:outline-none">
+          <div className="relative w-full cursor-default overflow-hidden rounded-xl border border-slate-300 bg-white text-left shadow-sm focus-within:border-primary-300 focus-within:ring-2 focus-within:ring-primary-100">
             <Combobox.Input
-              className="w-full border border-slate-700 bg-slate-900 py-2 pl-3 pr-10 text-sm leading-5 text-slate-100"
+              className="w-full bg-transparent py-2 pl-3 pr-10 text-sm leading-5 text-slate-900 focus:outline-none"
               displayValue={() => query}
               onChange={(event) => onQueryChange(event.target.value)}
               placeholder="Search keywords"
@@ -346,7 +348,7 @@ function KeywordSelector({
             </Combobox.Button>
           </div>
           {suggestions.length > 0 ? (
-            <Combobox.Options className="absolute z-10 mt-1 max-h-40 w-full overflow-auto rounded-md bg-slate-900 py-1 text-sm shadow-lg ring-1 ring-black/5">
+            <Combobox.Options className="absolute z-10 mt-1 max-h-40 w-full overflow-auto rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg">
               {suggestions.map((keyword) => (
                 <Combobox.Option
                   key={keyword}
@@ -354,7 +356,7 @@ function KeywordSelector({
                   className={({ active }) =>
                     clsx(
                       "relative cursor-default select-none py-2 pl-8 pr-4",
-                      active ? "bg-primary-600 text-white" : "text-slate-100"
+                      active ? "bg-primary-50 text-primary-600" : "text-slate-700"
                     )
                   }
                 >
@@ -362,7 +364,7 @@ function KeywordSelector({
                     <>
                       <span className="block truncate">{keyword}</span>
                       {active ? (
-                        <span className="absolute inset-y-0 left-0 flex items-center pl-2 text-white">
+                        <span className="absolute inset-y-0 left-0 flex items-center pl-2 text-primary-500">
                           <CheckIcon className="h-5 w-5" aria-hidden="true" />
                         </span>
                       ) : null}
@@ -379,13 +381,13 @@ function KeywordSelector({
         {selectedKeywords.map((keyword) => (
           <span
             key={keyword}
-            className="inline-flex items-center gap-2 rounded-full bg-primary-500/20 px-3 py-1 text-xs font-medium text-primary-200"
+            className="inline-flex items-center gap-2 rounded-full bg-primary-100 px-3 py-1 text-xs font-medium text-primary-700"
           >
             {keyword}
             <button
               type="button"
               onClick={() => onRemoveKeyword(keyword)}
-              className="rounded-full bg-primary-500/30 p-0.5 text-primary-100 hover:bg-primary-500/60"
+              className="rounded-full bg-primary-200/80 p-0.5 text-primary-700 hover:bg-primary-300"
             >
               <XMarkIcon className="h-3 w-3" />
             </button>
@@ -394,7 +396,7 @@ function KeywordSelector({
         <button
           type="button"
           onClick={() => (query ? onAddKeyword(query) : null)}
-          className="inline-flex items-center gap-1 text-xs font-medium text-primary-300"
+          className="inline-flex items-center gap-1 text-xs font-medium text-primary-600"
         >
           <PlusIcon className="h-4 w-4" />
           Add keyword

--- a/app/components/CardPreview.tsx
+++ b/app/components/CardPreview.tsx
@@ -10,17 +10,17 @@ interface CardPreviewProps {
 
 export function CardPreview({ card }: CardPreviewProps) {
   return (
-    <div className="card-surface relative mx-auto flex w-full max-w-[420px] flex-col overflow-hidden rounded-3xl border border-white/10 p-4 text-slate-100 shadow-2xl min-h-[520px]">
-      <header className="card-header relative flex items-center justify-between rounded-2xl px-4 py-2 text-slate-50 shadow-lg">
+    <div className="card-surface relative mx-auto flex min-h-[520px] w-full max-w-[420px] flex-col overflow-hidden rounded-3xl border border-slate-200 p-4 text-slate-900 shadow-xl">
+      <header className="card-header relative flex items-center justify-between rounded-2xl px-4 py-2 text-white shadow-lg">
         <span className="text-lg font-semibold uppercase tracking-wide">
           {card.name || "New card"}
         </span>
-        <span className="badge bg-white/20 text-base font-bold text-slate-900">
+        <span className="badge bg-white text-base font-bold text-primary-700">
           {card.cost}
         </span>
       </header>
 
-      <div className="mt-4 aspect-[3/4] overflow-hidden rounded-2xl border border-white/10 bg-slate-900/70">
+      <div className="mt-4 aspect-[3/4] overflow-hidden rounded-2xl border border-slate-200 bg-slate-100">
         {card.imageUrl ? (
           <Image
             src={card.imageUrl}
@@ -30,18 +30,18 @@ export function CardPreview({ card }: CardPreviewProps) {
             className="h-full w-full object-cover"
           />
         ) : (
-          <div className="flex h-full w-full items-center justify-center text-sm text-slate-400">
+          <div className="flex h-full w-full items-center justify-center text-sm text-slate-500">
             No artwork selected
           </div>
         )}
       </div>
 
-      <div className="mt-4 rounded-2xl bg-slate-900/70 p-4 text-sm">
-        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+      <div className="mt-4 rounded-2xl border border-slate-200 bg-white p-4 text-sm">
+        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
           <span>{card.type}</span>
           <span>{card.rarity}</span>
         </div>
-        <p className="mt-2 whitespace-pre-line text-slate-100">
+        <p className="mt-2 whitespace-pre-line text-slate-700">
           {card.text || "Rules text appears here. Describe effects and rules."}
         </p>
         <div className="mt-4 flex flex-wrap gap-2">
@@ -57,21 +57,21 @@ export function CardPreview({ card }: CardPreviewProps) {
         </div>
       </div>
 
-      <footer className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-slate-900/70 px-4 py-2">
-        <div className="flex items-center gap-3 text-slate-200">
+      <footer className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-2">
+        <div className="flex items-center gap-3 text-slate-700">
           <StatBadge label="ATK" value={card.stats.attack} />
           <StatBadge label="HP" value={card.stats.health} />
           {card.stats.armor ? <StatBadge label="ARM" value={card.stats.armor} /> : null}
         </div>
         <div className="text-right text-[11px] uppercase text-slate-500">
           <div>
-            Set: <span className="text-slate-300">{card.setId || "—"}</span>
+            Set: <span className="text-slate-700">{card.setId || "—"}</span>
           </div>
           <div>
-            Expansion: <span className="text-slate-300">{card.expansion || "—"}</span>
+            Expansion: <span className="text-slate-700">{card.expansion || "—"}</span>
           </div>
           <div>
-            Version: <span className="text-slate-300">{card.version || "v1.0.0"}</span>
+            Version: <span className="text-slate-700">{card.version || "v1.0.0"}</span>
           </div>
         </div>
       </footer>
@@ -83,12 +83,12 @@ function StatBadge({ label, value }: { label: string; value: number }) {
   return (
     <span
       className={clsx(
-        "flex h-12 w-12 flex-col items-center justify-center rounded-full border border-slate-700 bg-slate-950/80 text-xs font-bold",
-        "shadow-inner shadow-black/60"
+        "flex h-12 w-12 flex-col items-center justify-center rounded-full border border-slate-200 bg-white text-xs font-bold",
+        "shadow-inner shadow-slate-200"
       )}
     >
       <span className="text-[10px] text-slate-500">{label}</span>
-      <span className="text-lg text-slate-100">{value}</span>
+      <span className="text-lg text-slate-900">{value}</span>
     </span>
   );
 }

--- a/app/components/CardPreview.tsx
+++ b/app/components/CardPreview.tsx
@@ -10,7 +10,7 @@ interface CardPreviewProps {
 
 export function CardPreview({ card }: CardPreviewProps) {
   return (
-    <div className="card-surface relative mx-auto flex min-h-[520px] w-full max-w-[420px] flex-col overflow-hidden rounded-3xl border border-slate-200 p-4 text-slate-900 shadow-xl">
+    <div className="card-surface relative mx-auto flex min-h-[520px] w-full max-w-[420px] flex-col overflow-hidden rounded-3xl border border-slate-200 p-4 text-slate-900 shadow-xl dark:border-slate-700 dark:text-slate-100">
       <header className="card-header relative flex items-center justify-between rounded-2xl px-4 py-2 text-white shadow-lg">
         <span className="text-lg font-semibold uppercase tracking-wide">
           {card.name || "New card"}
@@ -20,7 +20,7 @@ export function CardPreview({ card }: CardPreviewProps) {
         </span>
       </header>
 
-      <div className="mt-4 aspect-[3/4] overflow-hidden rounded-2xl border border-slate-200 bg-slate-100">
+      <div className="mt-4 aspect-[3/4] overflow-hidden rounded-2xl border border-slate-200 bg-slate-100 dark:border-slate-700 dark:bg-slate-900/80">
         {card.imageUrl ? (
           <Image
             src={card.imageUrl}
@@ -36,12 +36,12 @@ export function CardPreview({ card }: CardPreviewProps) {
         )}
       </div>
 
-      <div className="mt-4 rounded-2xl border border-slate-200 bg-white p-4 text-sm">
-        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+      <div className="mt-4 rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200">
+        <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
           <span>{card.type}</span>
           <span>{card.rarity}</span>
         </div>
-        <p className="mt-2 whitespace-pre-line text-slate-700">
+        <p className="mt-2 whitespace-pre-line">
           {card.text || "Rules text appears here. Describe effects and rules."}
         </p>
         <div className="mt-4 flex flex-wrap gap-2">
@@ -52,26 +52,26 @@ export function CardPreview({ card }: CardPreviewProps) {
               </span>
             ))
           ) : (
-            <span className="text-xs text-slate-500">No keywords</span>
+            <span className="text-xs text-slate-500 dark:text-slate-400">No keywords</span>
           )}
         </div>
       </div>
 
-      <footer className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-2">
-        <div className="flex items-center gap-3 text-slate-700">
+      <footer className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-slate-700 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200">
+        <div className="flex items-center gap-3">
           <StatBadge label="ATK" value={card.stats.attack} />
           <StatBadge label="HP" value={card.stats.health} />
           {card.stats.armor ? <StatBadge label="ARM" value={card.stats.armor} /> : null}
         </div>
-        <div className="text-right text-[11px] uppercase text-slate-500">
+        <div className="text-right text-[11px] uppercase text-slate-500 dark:text-slate-400">
           <div>
-            Set: <span className="text-slate-700">{card.setId || "—"}</span>
+            Set: <span className="text-slate-700 dark:text-slate-200">{card.setId || "—"}</span>
           </div>
           <div>
-            Expansion: <span className="text-slate-700">{card.expansion || "—"}</span>
+            Expansion: <span className="text-slate-700 dark:text-slate-200">{card.expansion || "—"}</span>
           </div>
           <div>
-            Version: <span className="text-slate-700">{card.version || "v1.0.0"}</span>
+            Version: <span className="text-slate-700 dark:text-slate-200">{card.version || "v1.0.0"}</span>
           </div>
         </div>
       </footer>
@@ -84,11 +84,11 @@ function StatBadge({ label, value }: { label: string; value: number }) {
     <span
       className={clsx(
         "flex h-12 w-12 flex-col items-center justify-center rounded-full border border-slate-200 bg-white text-xs font-bold",
-        "shadow-inner shadow-slate-200"
+        "shadow-inner shadow-slate-200 dark:border-slate-600 dark:bg-slate-900/70 dark:text-slate-200"
       )}
     >
-      <span className="text-[10px] text-slate-500">{label}</span>
-      <span className="text-lg text-slate-900">{value}</span>
+      <span className="text-[10px] text-slate-500 dark:text-slate-400">{label}</span>
+      <span className="text-lg text-slate-900 dark:text-slate-100">{value}</span>
     </span>
   );
 }

--- a/app/components/DeckBuilder.tsx
+++ b/app/components/DeckBuilder.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { validateDeck } from "@/lib/validators";
 import type { DeckFormValues } from "@/lib/types";
 import { PlusIcon } from "@heroicons/react/24/outline";
+import { Select } from "@/app/components/ui/Select";
 
 const MOCK_LIBRARY = [
   { id: "c1", name: "Starwanderer", type: "Creature", rarity: "Rare" },
@@ -61,11 +62,11 @@ export function DeckBuilder() {
   const totalCards = deck.cards.reduce((sum, item) => sum + item.quantity, 0);
 
   return (
-    <section className="workspace-panel space-y-6">
+    <section className="workspace-panel space-y-6 text-slate-900 dark:text-slate-100">
       <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <h2 className="text-2xl font-semibold text-slate-900">Deck Check</h2>
-          <p className="text-sm text-slate-600">
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Deck Check</h2>
+          <p className="text-sm text-slate-600 dark:text-slate-400">
             Assemble a list and verify format constraints before locking a tournament build.
           </p>
         </div>
@@ -83,7 +84,7 @@ export function DeckBuilder() {
           <div className="workspace-panel__section space-y-3">
             <div className="space-y-1">
               <label>Deck name</label>
-              <p className="text-xs text-slate-500">Displayed on exports and deck registries.</p>
+              <p className="text-xs text-slate-500 dark:text-slate-400">Displayed on exports and deck registries.</p>
             </div>
             <input
               value={deck.name}
@@ -94,33 +95,33 @@ export function DeckBuilder() {
           <div className="workspace-panel__section space-y-3">
             <div className="space-y-1">
               <label>Format</label>
-              <p className="text-xs text-slate-500">Applies legality checks to the card pool.</p>
+              <p className="text-xs text-slate-500 dark:text-slate-400">Applies legality checks to the card pool.</p>
             </div>
-            <select
+            <Select
               value={deck.format}
               onChange={(event) => setDeck((prev) => ({ ...prev, format: event.target.value as DeckFormValues["format"] }))}
             >
               <option value="standard">Standard</option>
               <option value="unlimited">Unlimited</option>
-            </select>
+            </Select>
           </div>
         </div>
 
         <div className="workspace-panel__section space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700">Add card</h3>
-            <span className="text-[11px] uppercase text-slate-500">Library size: {MOCK_LIBRARY.length}</span>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-200">Add card</h3>
+            <span className="text-[11px] uppercase text-slate-500 dark:text-slate-400">Library size: {MOCK_LIBRARY.length}</span>
           </div>
           <div className="flex flex-col gap-3 lg:flex-row">
             <div className="flex flex-1 flex-col gap-2">
               <label>Card</label>
-              <select value={cardId} onChange={(event) => setCardId(event.target.value)}>
+              <Select value={cardId} onChange={(event) => setCardId(event.target.value)}>
                 {MOCK_LIBRARY.map((card) => (
                   <option key={card.id} value={card.id}>
                     {card.name} – {card.type}
                   </option>
                 ))}
-              </select>
+              </Select>
             </div>
             <div className="w-full space-y-2 lg:w-32">
               <label>Quantity</label>
@@ -139,7 +140,11 @@ export function DeckBuilder() {
                 }}
               />
             </div>
-            <button type="button" onClick={addCardToDeck} className="lg:w-40">
+            <button
+              type="button"
+              onClick={addCardToDeck}
+              className="lg:w-40 rounded-full bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-400 focus-visible:outline focus-visible:outline-primary-300 dark:bg-primary-600 dark:hover:bg-primary-500"
+            >
               <PlusIcon className="mr-2 h-4 w-4" />
               Add card
             </button>
@@ -148,31 +153,31 @@ export function DeckBuilder() {
 
         <div className="workspace-panel__section space-y-4">
           <header className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-200">
               Card list ({totalCards} cards)
             </h3>
-            <span className="text-xs text-slate-500">Max 60 cards</span>
+            <span className="text-xs text-slate-500 dark:text-slate-400">Max 60 cards</span>
           </header>
-          <ul className="space-y-2 text-sm text-slate-700">
+          <ul className="space-y-2 text-sm text-slate-700 dark:text-slate-200">
             {deck.cards.length === 0 ? (
-              <li className="text-xs text-slate-500">No cards have been added yet.</li>
+              <li className="text-xs text-slate-500 dark:text-slate-400">No cards have been added yet.</li>
             ) : (
               deck.cards.map((entry) => {
                 const card = MOCK_LIBRARY.find((item) => item.id === entry.cardId);
                 return (
-                  <li key={entry.cardId} className="flex items-center justify-between rounded-xl bg-slate-100 px-3 py-2">
+                  <li key={entry.cardId} className="flex items-center justify-between rounded-xl bg-slate-100 px-3 py-2 dark:bg-slate-800/70">
                     <div>
-                      <p className="font-medium text-slate-900">{card?.name ?? entry.cardId}</p>
-                      <p className="text-xs text-slate-500">
+                      <p className="font-medium text-slate-900 dark:text-slate-100">{card?.name ?? entry.cardId}</p>
+                      <p className="text-xs text-slate-500 dark:text-slate-400">
                         {card?.type ?? "Unknown type"} • {card?.rarity ?? "?"}
                       </p>
                     </div>
                     <div className="flex items-center gap-4 text-sm">
-                      <span className="rounded-full bg-primary-100 px-2.5 py-1 text-xs font-semibold text-primary-600">x{entry.quantity}</span>
+                      <span className="rounded-full bg-primary-100 px-2.5 py-1 text-xs font-semibold text-primary-600 dark:bg-primary-500/20 dark:text-primary-200">x{entry.quantity}</span>
                       <button
                         type="button"
                         onClick={() => removeCard(entry.cardId)}
-                        className="text-xs text-rose-500 transition hover:text-rose-400"
+                        className="text-xs text-rose-500 transition hover:text-rose-400 dark:text-rose-400 dark:hover:text-rose-300"
                       >
                         Remove
                       </button>
@@ -185,13 +190,13 @@ export function DeckBuilder() {
         </div>
 
         {validationMessage ? (
-          <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700 dark:border-emerald-500/50 dark:bg-emerald-500/10 dark:text-emerald-200">
             {validationMessage}
           </div>
         ) : null}
 
         {errors.length > 0 ? (
-          <div className="rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-600">
+          <div className="rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-600 dark:border-rose-400/40 dark:bg-rose-500/10 dark:text-rose-200">
             <ul className="list-inside list-disc space-y-1">
               {errors.map((error, index) => (
                 <li key={`${error}-${index}`}>{error}</li>

--- a/app/components/DeckBuilder.tsx
+++ b/app/components/DeckBuilder.tsx
@@ -64,12 +64,16 @@ export function DeckBuilder() {
     <section className="workspace-panel space-y-6">
       <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
-          <h2 className="text-2xl font-semibold text-white">Deck Check</h2>
-          <p className="text-sm text-slate-400">
+          <h2 className="text-2xl font-semibold text-slate-900">Deck Check</h2>
+          <p className="text-sm text-slate-600">
             Assemble a list and verify format constraints before locking a tournament build.
           </p>
         </div>
-        <button type="button" onClick={validate} className="rounded-full border border-primary-400/40 bg-primary-500/90 px-5 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-primary-500/20 transition hover:bg-primary-400">
+        <button
+          type="button"
+          onClick={validate}
+          className="rounded-full border border-primary-200 bg-primary-500 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-400"
+        >
           Validate deck
         </button>
       </header>
@@ -104,13 +108,13 @@ export function DeckBuilder() {
 
         <div className="workspace-panel__section space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-200">Add card</h3>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700">Add card</h3>
             <span className="text-[11px] uppercase text-slate-500">Library size: {MOCK_LIBRARY.length}</span>
           </div>
           <div className="flex flex-col gap-3 lg:flex-row">
             <div className="flex flex-1 flex-col gap-2">
               <label>Card</label>
-              <select value={cardId} onChange={(event) => setCardId(event.target.value)} className="bg-slate-900">
+              <select value={cardId} onChange={(event) => setCardId(event.target.value)}>
                 {MOCK_LIBRARY.map((card) => (
                   <option key={card.id} value={card.id}>
                     {card.name} – {card.type}
@@ -144,31 +148,31 @@ export function DeckBuilder() {
 
         <div className="workspace-panel__section space-y-4">
           <header className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-200">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700">
               Card list ({totalCards} cards)
             </h3>
             <span className="text-xs text-slate-500">Max 60 cards</span>
           </header>
-          <ul className="space-y-2 text-sm text-slate-200">
+          <ul className="space-y-2 text-sm text-slate-700">
             {deck.cards.length === 0 ? (
               <li className="text-xs text-slate-500">No cards have been added yet.</li>
             ) : (
               deck.cards.map((entry) => {
                 const card = MOCK_LIBRARY.find((item) => item.id === entry.cardId);
                 return (
-                  <li key={entry.cardId} className="flex items-center justify-between rounded-xl bg-slate-900/70 px-3 py-2">
+                  <li key={entry.cardId} className="flex items-center justify-between rounded-xl bg-slate-100 px-3 py-2">
                     <div>
-                      <p className="font-medium text-slate-100">{card?.name ?? entry.cardId}</p>
+                      <p className="font-medium text-slate-900">{card?.name ?? entry.cardId}</p>
                       <p className="text-xs text-slate-500">
                         {card?.type ?? "Unknown type"} • {card?.rarity ?? "?"}
                       </p>
                     </div>
                     <div className="flex items-center gap-4 text-sm">
-                      <span className="badge bg-primary-500/20 text-primary-200">x{entry.quantity}</span>
+                      <span className="rounded-full bg-primary-100 px-2.5 py-1 text-xs font-semibold text-primary-600">x{entry.quantity}</span>
                       <button
                         type="button"
                         onClick={() => removeCard(entry.cardId)}
-                        className="text-xs text-rose-300 transition hover:text-rose-200"
+                        className="text-xs text-rose-500 transition hover:text-rose-400"
                       >
                         Remove
                       </button>
@@ -181,13 +185,13 @@ export function DeckBuilder() {
         </div>
 
         {validationMessage ? (
-          <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
             {validationMessage}
           </div>
         ) : null}
 
         {errors.length > 0 ? (
-          <div className="rounded-xl border border-rose-500/40 bg-rose-500/10 p-4 text-sm text-rose-200">
+          <div className="rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-600">
             <ul className="list-inside list-disc space-y-1">
               {errors.map((error, index) => (
                 <li key={`${error}-${index}`}>{error}</li>

--- a/app/components/ExportPanel.tsx
+++ b/app/components/ExportPanel.tsx
@@ -31,15 +31,15 @@ export function ExportPanel({ card }: ExportPanelProps) {
     <section className="workspace-panel space-y-6">
       <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div className="space-y-1">
-          <h2 className="text-2xl font-semibold text-white">Export Toolkit</h2>
-          <p className="text-sm text-slate-400">
+          <h2 className="text-2xl font-semibold text-slate-900">Export Toolkit</h2>
+          <p className="text-sm text-slate-600">
             Package the current card as structured data or production-ready assets.
           </p>
         </div>
         <button
           type="button"
           onClick={handleExport}
-          className="inline-flex items-center gap-2 rounded-full border border-primary-400/40 bg-primary-500/90 px-5 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-primary-500/25 transition hover:bg-primary-400"
+          className="inline-flex items-center gap-2 rounded-full border border-primary-200 bg-primary-500 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-400"
         >
           <DocumentArrowDownIcon className="h-5 w-5" />
           Export {format.toUpperCase()}
@@ -49,13 +49,13 @@ export function ExportPanel({ card }: ExportPanelProps) {
       <div className="grid gap-4 lg:grid-cols-[minmax(0,180px)_1fr] lg:items-start">
         <div className="space-y-3">
           <div className="space-y-1">
-            <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Format</label>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Format</label>
             <p className="text-xs text-slate-500">Choose the pipeline destination.</p>
           </div>
           <select
             value={format}
             onChange={(event) => setFormat(event.target.value as typeof format)}
-            className="rounded-2xl border border-white/10 bg-slate-950/70 px-3 py-2 text-sm text-slate-200 shadow-inner focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-400/30"
+            className="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-200"
           >
             <option value="json">JSON</option>
             <option value="png">PNG</option>
@@ -64,10 +64,10 @@ export function ExportPanel({ card }: ExportPanelProps) {
         </div>
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Preview</label>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Preview</label>
             <span className="text-[11px] uppercase text-slate-500">Read-only</span>
           </div>
-          <pre className="h-64 w-full overflow-auto rounded-2xl border border-white/5 bg-slate-950/70 p-4 font-mono text-xs text-slate-200">
+          <pre className="h-64 w-full overflow-auto rounded-2xl border border-slate-200 bg-slate-50 p-4 font-mono text-xs text-slate-700">
             {jsonPreview}
           </pre>
         </div>

--- a/app/components/ExportPanel.tsx
+++ b/app/components/ExportPanel.tsx
@@ -47,8 +47,8 @@ export function ExportPanel({ card }: ExportPanelProps) {
         </button>
       </header>
 
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,180px)_1fr] lg:items-start">
-        <div className="space-y-3">
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,260px)_minmax(0,1fr)] xl:items-start 2xl:gap-10">
+        <div className="space-y-5">
           <div className="space-y-1">
             <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Format</label>
             <p className="text-xs text-slate-500 dark:text-slate-400">Choose the pipeline destination.</p>
@@ -59,14 +59,16 @@ export function ExportPanel({ card }: ExportPanelProps) {
             <option value="pdf">PDF</option>
           </Select>
         </div>
-        <div className="space-y-2">
+        <div className="space-y-3">
           <div className="flex items-center justify-between">
             <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Preview</label>
             <span className="text-[11px] uppercase text-slate-500 dark:text-slate-400">Read-only</span>
           </div>
-          <pre className="max-h-72 min-h-[18rem] w-full overflow-auto rounded-2xl border border-slate-200 bg-slate-50 p-4 font-mono text-xs text-slate-700 shadow-inner shadow-slate-200 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200">
-            {jsonPreview}
-          </pre>
+          <div className="max-h-[28rem] min-h-[18rem] w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-50/90 shadow-inner shadow-slate-200 dark:border-slate-700 dark:bg-slate-900/70">
+            <pre className="h-full w-full overflow-auto p-4 font-mono text-xs leading-relaxed text-slate-700 dark:text-slate-200 sm:text-sm xl:p-5 xl:text-[0.95rem] whitespace-pre-wrap break-words">
+              {jsonPreview}
+            </pre>
+          </div>
         </div>
       </div>
     </section>

--- a/app/components/ExportPanel.tsx
+++ b/app/components/ExportPanel.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import type { CardFormValues } from "@/lib/types";
 import { DocumentArrowDownIcon } from "@heroicons/react/24/outline";
+import { Select } from "@/app/components/ui/Select";
 
 interface ExportPanelProps {
   card: CardFormValues;
@@ -28,11 +29,11 @@ export function ExportPanel({ card }: ExportPanelProps) {
   }
 
   return (
-    <section className="workspace-panel space-y-6">
+    <section className="workspace-panel space-y-6 text-slate-900 dark:text-slate-100">
       <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div className="space-y-1">
-          <h2 className="text-2xl font-semibold text-slate-900">Export Toolkit</h2>
-          <p className="text-sm text-slate-600">
+          <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Export Toolkit</h2>
+          <p className="text-sm text-slate-600 dark:text-slate-400">
             Package the current card as structured data or production-ready assets.
           </p>
         </div>
@@ -49,25 +50,21 @@ export function ExportPanel({ card }: ExportPanelProps) {
       <div className="grid gap-4 lg:grid-cols-[minmax(0,180px)_1fr] lg:items-start">
         <div className="space-y-3">
           <div className="space-y-1">
-            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Format</label>
-            <p className="text-xs text-slate-500">Choose the pipeline destination.</p>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Format</label>
+            <p className="text-xs text-slate-500 dark:text-slate-400">Choose the pipeline destination.</p>
           </div>
-          <select
-            value={format}
-            onChange={(event) => setFormat(event.target.value as typeof format)}
-            className="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-200"
-          >
+          <Select value={format} onChange={(event) => setFormat(event.target.value as typeof format)}>
             <option value="json">JSON</option>
             <option value="png">PNG</option>
             <option value="pdf">PDF</option>
-          </select>
+          </Select>
         </div>
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Preview</label>
-            <span className="text-[11px] uppercase text-slate-500">Read-only</span>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Preview</label>
+            <span className="text-[11px] uppercase text-slate-500 dark:text-slate-400">Read-only</span>
           </div>
-          <pre className="h-64 w-full overflow-auto rounded-2xl border border-slate-200 bg-slate-50 p-4 font-mono text-xs text-slate-700">
+          <pre className="max-h-72 min-h-[18rem] w-full overflow-auto rounded-2xl border border-slate-200 bg-slate-50 p-4 font-mono text-xs text-slate-700 shadow-inner shadow-slate-200 dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200">
             {jsonPreview}
           </pre>
         </div>

--- a/app/components/KeywordManager.tsx
+++ b/app/components/KeywordManager.tsx
@@ -23,8 +23,8 @@ export function KeywordManager() {
   return (
     <section className="workspace-panel space-y-6">
       <header className="space-y-2">
-        <h2 className="text-2xl font-semibold text-white">Keyword Management</h2>
-        <p className="text-sm text-slate-400">
+        <h2 className="text-2xl font-semibold text-slate-900">Keyword Management</h2>
+        <p className="text-sm text-slate-600">
           Curate the shared vocabulary that powers rules text, search filters, and deck validation.
         </p>
       </header>
@@ -33,10 +33,10 @@ export function KeywordManager() {
         {keywordGroups.map((group) => (
           <article key={group.name} className="workspace-panel__section space-y-3">
             <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold uppercase tracking-wide text-primary-300">{group.name}</h3>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-primary-600">{group.name}</h3>
               <span className="text-[11px] uppercase text-slate-500">{group.keywords.length} keywords</span>
             </div>
-            <ul className="space-y-2 text-sm text-slate-200">
+            <ul className="space-y-2 text-sm text-slate-700">
               {group.keywords.map((keyword) => (
                 <li key={keyword} className="flex items-center justify-between">
                   <span>{keyword}</span>
@@ -50,7 +50,7 @@ export function KeywordManager() {
 
       <div className="workspace-panel__section workspace-panel__section--muted space-y-4">
         <div className="space-y-1">
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Add custom keyword</h3>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700">Add custom keyword</h3>
           <p className="text-xs text-slate-500">Extend the keyword pool with new mechanics or localized terminology.</p>
         </div>
         <div className="flex flex-col gap-2 sm:flex-row">
@@ -66,9 +66,9 @@ export function KeywordManager() {
           </button>
         </div>
         {customKeywords.length > 0 ? (
-          <ul className="flex flex-wrap gap-2 text-xs text-primary-200">
+          <ul className="flex flex-wrap gap-2 text-xs text-primary-600">
             {customKeywords.map((keyword) => (
-              <li key={keyword} className="rounded-full bg-primary-500/20 px-3 py-1">
+              <li key={keyword} className="rounded-full bg-primary-100 px-3 py-1">
                 {keyword}
               </li>
             ))}

--- a/app/components/KeywordManager.tsx
+++ b/app/components/KeywordManager.tsx
@@ -21,10 +21,10 @@ export function KeywordManager() {
   }
 
   return (
-    <section className="workspace-panel space-y-6">
+    <section className="workspace-panel space-y-6 text-slate-900 dark:text-slate-100">
       <header className="space-y-2">
-        <h2 className="text-2xl font-semibold text-slate-900">Keyword Management</h2>
-        <p className="text-sm text-slate-600">
+        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Keyword Management</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
           Curate the shared vocabulary that powers rules text, search filters, and deck validation.
         </p>
       </header>
@@ -33,14 +33,14 @@ export function KeywordManager() {
         {keywordGroups.map((group) => (
           <article key={group.name} className="workspace-panel__section space-y-3">
             <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold uppercase tracking-wide text-primary-600">{group.name}</h3>
-              <span className="text-[11px] uppercase text-slate-500">{group.keywords.length} keywords</span>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-primary-600 dark:text-primary-300">{group.name}</h3>
+              <span className="text-[11px] uppercase text-slate-500 dark:text-slate-400">{group.keywords.length} keywords</span>
             </div>
-            <ul className="space-y-2 text-sm text-slate-700">
+            <ul className="space-y-2 text-sm text-slate-700 dark:text-slate-200">
               {group.keywords.map((keyword) => (
                 <li key={keyword} className="flex items-center justify-between">
                   <span>{keyword}</span>
-                  <span className="text-xs text-slate-500">{group.name}</span>
+                  <span className="text-xs text-slate-500 dark:text-slate-400">{group.name}</span>
                 </li>
               ))}
             </ul>
@@ -50,8 +50,8 @@ export function KeywordManager() {
 
       <div className="workspace-panel__section workspace-panel__section--muted space-y-4">
         <div className="space-y-1">
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700">Add custom keyword</h3>
-          <p className="text-xs text-slate-500">Extend the keyword pool with new mechanics or localized terminology.</p>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-200">Add custom keyword</h3>
+          <p className="text-xs text-slate-500 dark:text-slate-400">Extend the keyword pool with new mechanics or localized terminology.</p>
         </div>
         <div className="flex flex-col gap-2 sm:flex-row">
           <input
@@ -60,15 +60,19 @@ export function KeywordManager() {
             placeholder="e.g. Chronoshift"
             className="flex-1"
           />
-          <button type="button" onClick={handleAddKeyword} className="sm:w-40">
+          <button
+            type="button"
+            onClick={handleAddKeyword}
+            className="sm:w-40 rounded-full bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-400 focus-visible:outline focus-visible:outline-primary-300 dark:bg-primary-600 dark:hover:bg-primary-500"
+          >
             <PlusIcon className="mr-2 h-4 w-4" />
             Add keyword
           </button>
         </div>
         {customKeywords.length > 0 ? (
-          <ul className="flex flex-wrap gap-2 text-xs text-primary-600">
+          <ul className="flex flex-wrap gap-2 text-xs text-primary-600 dark:text-primary-200">
             {customKeywords.map((keyword) => (
-              <li key={keyword} className="rounded-full bg-primary-100 px-3 py-1">
+              <li key={keyword} className="rounded-full bg-primary-100 px-3 py-1 dark:bg-primary-500/20">
                 {keyword}
               </li>
             ))}

--- a/app/components/ui/Select.tsx
+++ b/app/components/ui/Select.tsx
@@ -16,7 +16,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select
         ref={ref}
         {...props}
         className={clsx(
-          "w-full appearance-none rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner shadow-slate-100 focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:shadow-none dark:focus:border-primary-500 dark:focus:ring-primary-600/40",
+          "w-full appearance-none rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-sm text-slate-900 shadow-inner shadow-slate-100 focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:shadow-none dark:focus:border-primary-500 dark:focus:ring-primary-600/40 sm:text-[0.95rem]",
           className
         )}
       >

--- a/app/components/ui/Select.tsx
+++ b/app/components/ui/Select.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { forwardRef } from "react";
+import { ChevronUpDownIcon } from "@heroicons/react/24/outline";
+import clsx from "classnames";
+
+type SelectProps = React.ComponentPropsWithoutRef<"select">;
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  { className, children, ...props },
+  ref
+) {
+  return (
+    <div className="relative">
+      <select
+        ref={ref}
+        {...props}
+        className={clsx(
+          "w-full appearance-none rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-inner shadow-slate-100 focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:shadow-none dark:focus:border-primary-500 dark:focus:ring-primary-600/40",
+          className
+        )}
+      >
+        {children}
+      </select>
+      <ChevronUpDownIcon className="pointer-events-none absolute right-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400 dark:text-slate-500" />
+    </div>
+  );
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,23 +2,29 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: light;
-}
+@layer base {
+  html {
+    font-size: clamp(15px, 0.6vw + 11px, 18px);
+  }
 
-body {
-  @apply min-h-screen bg-neutral-200 text-slate-900 antialiased transition-colors dark:bg-slate-950 dark:text-slate-100;
-  font-feature-settings: "ss01" 1, "cv02" 1;
-}
+  :root {
+    color-scheme: light;
+  }
 
-a {
-  @apply text-primary-600 transition hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-300;
+  body {
+    @apply min-h-screen bg-neutral-200 text-slate-900 antialiased transition-colors dark:bg-slate-950 dark:text-slate-100;
+    font-feature-settings: "ss01" 1, "cv02" 1;
+  }
+
+  a {
+    @apply text-primary-600 transition hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-300;
+  }
 }
 
 input,
 textarea,
 select {
-  @apply w-full appearance-none rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 shadow-inner shadow-slate-100 focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-400 dark:shadow-none dark:focus:border-primary-500 dark:focus:ring-primary-600/40;
+  @apply w-full appearance-none rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-sm text-slate-900 placeholder:text-slate-400 shadow-inner shadow-slate-100 focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-400 dark:shadow-none dark:focus:border-primary-500 dark:focus:ring-primary-600/40 sm:text-[0.95rem];
 }
 
 label {
@@ -30,11 +36,11 @@ button {
 }
 
 .workspace-panel {
-  @apply rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-lg shadow-slate-200/50 backdrop-blur dark:border-slate-700 dark:bg-slate-900/90 dark:shadow-black/30;
+  @apply rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-lg shadow-slate-200/50 backdrop-blur dark:border-slate-700 dark:bg-slate-900/90 dark:shadow-black/30 sm:p-7 xl:p-8 2xl:p-10;
 }
 
 .workspace-panel__section {
-  @apply rounded-2xl border border-slate-200 bg-slate-50 p-5 shadow-sm shadow-slate-200/60 dark:border-slate-700 dark:bg-slate-800/70 dark:shadow-black/20;
+  @apply rounded-2xl border border-slate-200 bg-slate-50 p-5 shadow-sm shadow-slate-200/60 dark:border-slate-700 dark:bg-slate-800/70 dark:shadow-black/20 sm:p-6 xl:p-7;
 }
 
 .workspace-panel__section--muted {

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,38 +7,38 @@
 }
 
 body {
-  @apply min-h-screen bg-neutral-200 text-slate-900 antialiased;
+  @apply min-h-screen bg-neutral-200 text-slate-900 antialiased transition-colors dark:bg-slate-950 dark:text-slate-100;
   font-feature-settings: "ss01" 1, "cv02" 1;
 }
 
 a {
-  @apply text-primary-600 hover:text-primary-500;
+  @apply text-primary-600 transition hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-300;
 }
 
 input,
 textarea,
 select {
-  @apply rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-200;
+  @apply w-full appearance-none rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 shadow-inner shadow-slate-100 focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-400 dark:shadow-none dark:focus:border-primary-500 dark:focus:ring-primary-600/40;
 }
 
 label {
-  @apply text-xs font-semibold uppercase tracking-wide text-slate-500;
+  @apply text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300;
 }
 
 button {
-  @apply inline-flex items-center justify-center rounded-full bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-300 disabled:cursor-not-allowed disabled:opacity-60;
+  @apply inline-flex items-center justify-center text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-300 disabled:cursor-not-allowed disabled:opacity-60;
 }
 
 .workspace-panel {
-  @apply rounded-3xl border border-slate-200 bg-white p-6 shadow-lg;
+  @apply rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-lg shadow-slate-200/50 backdrop-blur dark:border-slate-700 dark:bg-slate-900/90 dark:shadow-black/30;
 }
 
 .workspace-panel__section {
-  @apply rounded-2xl border border-slate-200 bg-slate-50 p-5 shadow-sm;
+  @apply rounded-2xl border border-slate-200 bg-slate-50 p-5 shadow-sm shadow-slate-200/60 dark:border-slate-700 dark:bg-slate-800/70 dark:shadow-black/20;
 }
 
 .workspace-panel__section--muted {
-  @apply border-dashed border-slate-300 bg-slate-100;
+  @apply border-dashed border-slate-300 bg-slate-100 dark:border-slate-600 dark:bg-slate-800;
 }
 
 .card-surface {
@@ -47,10 +47,20 @@ button {
   border: 1px solid rgba(148, 163, 184, 0.35);
 }
 
+.dark .card-surface {
+  background: linear-gradient(145deg, #1e293b, #0f172a);
+  box-shadow: 0 32px 60px -28px rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(51, 65, 85, 0.7);
+}
+
 .card-header {
   background: linear-gradient(120deg, #8b5cf6, #6366f1);
 }
 
+.dark .card-header {
+  background: linear-gradient(120deg, #7c3aed, #4c1d95);
+}
+
 .badge {
-  @apply rounded-full bg-primary-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-primary-700;
+  @apply rounded-full bg-primary-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-primary-700 dark:bg-primary-500/20 dark:text-primary-200;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,101 +3,54 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: dark;
+  color-scheme: light;
 }
 
 body {
-  @apply relative min-h-screen bg-slate-950 text-slate-100 antialiased;
-  background: radial-gradient(circle at top left, rgba(67, 56, 202, 0.4), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.25), transparent 60%),
-    linear-gradient(160deg, rgba(2, 6, 23, 0.95), rgba(15, 23, 42, 0.9));
-  overflow-x: hidden;
+  @apply min-h-screen bg-neutral-200 text-slate-900 antialiased;
+  font-feature-settings: "ss01" 1, "cv02" 1;
 }
 
 a {
-  @apply text-primary-300 hover:text-primary-200;
+  @apply text-primary-600 hover:text-primary-500;
 }
 
-input, textarea, select {
-  @apply bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500;
+input,
+textarea,
+select {
+  @apply rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-200;
 }
 
 label {
-  @apply text-xs font-semibold uppercase tracking-wide text-slate-400;
+  @apply text-xs font-semibold uppercase tracking-wide text-slate-500;
 }
 
 button {
-  @apply inline-flex items-center justify-center rounded-md bg-primary-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-400 disabled:opacity-60 disabled:cursor-not-allowed;
-}
-
-.workspace-shell {
-  @apply relative isolate mx-auto max-w-7xl px-6 py-12 sm:px-8 lg:px-12;
-}
-
-.workspace-shell::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  margin: auto;
-  width: min(65%, 760px);
-  height: 65%;
-  border-radius: 9999px;
-  background: radial-gradient(circle, rgba(59, 130, 246, 0.2), transparent 60%);
-  filter: blur(80px);
-  opacity: 0.6;
-  z-index: -1;
-}
-
-.dashboard-header {
-  @apply flex flex-col gap-8 rounded-3xl border border-white/10 bg-slate-900/70 p-6 shadow-[0_30px_60px_-45px_rgba(15,23,42,0.9)] backdrop-blur;
-  @apply lg:flex-row lg:items-center lg:justify-between lg:gap-12;
-}
-
-.dashboard-metrics {
-  @apply grid w-full gap-4 sm:grid-cols-2 lg:max-w-xl lg:grid-cols-2 xl:max-w-none xl:grid-cols-4;
-}
-
-.dashboard-metrics div {
-  @apply flex flex-col gap-1 rounded-2xl border border-white/5 bg-slate-950/60 p-4 text-left shadow-inner shadow-black/30;
-}
-
-.dashboard-metrics dt {
-  @apply text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-500;
-}
-
-.dashboard-metrics dd {
-  @apply text-sm font-medium text-slate-100;
-}
-
-.dashboard-grid {
-  @apply grid gap-8 items-start xl:grid-cols-[minmax(0,1.7fr)_minmax(0,1fr)] xl:gap-10 2xl:gap-12;
+  @apply inline-flex items-center justify-center rounded-full bg-primary-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-300 disabled:cursor-not-allowed disabled:opacity-60;
 }
 
 .workspace-panel {
-  @apply rounded-3xl border border-white/10 bg-slate-900/70 p-6 shadow-[0_32px_60px_-45px_rgba(15,23,42,0.9)];
-  backdrop-filter: blur(18px);
+  @apply rounded-3xl border border-slate-200 bg-white p-6 shadow-lg;
 }
 
 .workspace-panel__section {
-  @apply rounded-2xl border border-white/5 bg-slate-950/60 p-5 shadow-inner shadow-black/20;
+  @apply rounded-2xl border border-slate-200 bg-slate-50 p-5 shadow-sm;
 }
 
 .workspace-panel__section--muted {
-  @apply border-dashed border-white/10 bg-slate-950/40;
+  @apply border-dashed border-slate-300 bg-slate-100;
 }
 
 .card-surface {
-  background: radial-gradient(circle at top left, rgba(139, 92, 246, 0.35), transparent 60%),
-    radial-gradient(circle at bottom right, rgba(14, 116, 144, 0.25), transparent 55%),
-    linear-gradient(145deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.95));
-  box-shadow: 0 20px 40px -20px rgba(15, 23, 42, 0.8);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(145deg, #f8fafc, #e2e8f0);
+  box-shadow: 0 24px 60px -30px rgba(15, 23, 42, 0.25);
+  border: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .card-header {
-  background: linear-gradient(120deg, rgba(139, 92, 246, 0.9), rgba(14, 165, 233, 0.7));
+  background: linear-gradient(120deg, #8b5cf6, #6366f1);
 }
 
 .badge {
-  @apply rounded-full bg-slate-800/60 px-2.5 py-1 text-xs font-medium uppercase tracking-wide text-slate-300;
+  @apply rounded-full bg-primary-100 px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-primary-700;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -56,20 +56,20 @@ const WORKSPACES: Array<{
 export default function HomePage() {
   const [card, setCard] = useState<CardFormValues>(initialCard);
   const [activeWorkspace, setActiveWorkspace] = useState<WorkspaceId>("card-editor");
-  const [theme, setTheme] = useState<"light" | "dark">("light");
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const settingsRef = useRef<HTMLDivElement | null>(null);
+  const [theme, setTheme] = useState<"light" | "dark">(() => {
+    if (typeof window === "undefined") {
+      return "light";
+    }
 
-  useEffect(() => {
     const stored = window.localStorage.getItem("cardforge-theme");
     if (stored === "light" || stored === "dark") {
-      setTheme(stored);
-      return;
+      return stored;
     }
-    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-      setTheme("dark");
-    }
-  }, []);
+
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  });
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const settingsRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     document.documentElement.classList.toggle("dark", theme === "dark");
@@ -192,15 +192,15 @@ export default function HomePage() {
       </aside>
 
       <div className="flex flex-1 justify-center px-4 py-8 sm:px-6 lg:px-10 lg:py-12">
-        <div className="flex w-full max-w-6xl flex-col gap-8 xl:grid xl:grid-cols-[minmax(0,1.25fr)_minmax(0,0.9fr)] xl:items-start xl:gap-10">
-          <section className="order-1 flex flex-col gap-6">
+        <div className="flex w-full max-w-6xl flex-col gap-8 lg:flex-row lg:items-start lg:gap-12 xl:max-w-7xl">
+          <section className="flex min-w-0 flex-[1.6] flex-col gap-6">
             {activeWorkspace === "card-editor" ? <CardEditor onChange={setCard} /> : null}
             {activeWorkspace === "deck-check" ? <DeckBuilder /> : null}
             {activeWorkspace === "export" ? <ExportPanel card={card} /> : null}
             {activeWorkspace === "keyword" ? <KeywordManager /> : null}
           </section>
 
-          <section className="order-2 flex items-start justify-center xl:order-none xl:justify-end">
+          <section className="flex w-full shrink-0 justify-center lg:w-auto lg:justify-end">
             <CardPreview card={card} />
           </section>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -119,7 +119,7 @@ export default function HomePage() {
                 type="button"
                 onClick={() => handleWorkspaceSelect(workspace.id)}
                 className={clsx(
-                  "flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-left transition focus-visible:outline-none",
+                  "flex w-full items-center gap-4 rounded-2xl px-4 py-4 text-left transition focus-visible:outline-none",
                   activeWorkspace === workspace.id
                     ? "bg-primary-500 text-white shadow-lg shadow-primary-200/60 dark:bg-primary-600 dark:shadow-primary-900/40"
                     : "text-slate-600 hover:bg-white/70 dark:text-slate-300 dark:hover:bg-slate-800/80"
@@ -127,7 +127,7 @@ export default function HomePage() {
               >
                 <span
                   className={clsx(
-                    "flex h-10 w-10 items-center justify-center rounded-full border text-sm font-semibold transition",
+                    "flex h-11 w-11 items-center justify-center rounded-full border text-sm font-semibold transition",
                     activeWorkspace === workspace.id
                       ? "border-white/60 bg-white/20 text-white"
                       : "border-slate-300 bg-white text-slate-600 dark:border-slate-600 dark:bg-slate-900/60 dark:text-slate-300"
@@ -153,9 +153,9 @@ export default function HomePage() {
           <button
             type="button"
             onClick={() => setIsSettingsOpen((prev) => !prev)}
-            className="flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-sm font-semibold text-slate-600 transition hover:bg-white/70 dark:text-slate-300 dark:hover:bg-slate-800/80"
+            className="flex w-full items-center gap-4 rounded-2xl px-4 py-4 text-sm font-semibold text-slate-600 transition hover:bg-white/70 dark:text-slate-300 dark:hover:bg-slate-800/80"
           >
-            <span className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-300 bg-white text-xs font-semibold uppercase tracking-wider text-slate-600 dark:border-slate-600 dark:bg-slate-900/70 dark:text-slate-300">
+            <span className="flex h-11 w-11 items-center justify-center rounded-full border border-slate-300 bg-white text-xs font-semibold uppercase tracking-wider text-slate-600 dark:border-slate-600 dark:bg-slate-900/70 dark:text-slate-300">
               ⚙️
             </span>
             Settings
@@ -192,7 +192,7 @@ export default function HomePage() {
       </aside>
 
       <div className="flex flex-1 justify-center px-4 py-8 sm:px-6 lg:px-12 lg:py-12 2xl:px-16 2xl:py-16">
-        <div className="flex w-full max-w-5xl flex-col gap-8 lg:flex-row lg:items-start lg:gap-12 xl:max-w-[1400px] 2xl:max-w-[1600px] 2xl:gap-16">
+        <div className="flex w-full max-w-5xl flex-col gap-8 lg:flex-row lg:items-stretch lg:gap-12 xl:max-w-[1400px] 2xl:max-w-[1600px] 2xl:gap-16">
           <section className="flex min-w-0 flex-[1.7] flex-col gap-6 2xl:gap-8">
             {activeWorkspace === "card-editor" ? <CardEditor onChange={setCard} /> : null}
             {activeWorkspace === "deck-check" ? <DeckBuilder /> : null}
@@ -200,7 +200,7 @@ export default function HomePage() {
             {activeWorkspace === "keyword" ? <KeywordManager /> : null}
           </section>
 
-          <section className="flex w-full shrink-0 justify-center lg:w-auto lg:min-w-[340px] lg:justify-end xl:min-w-[380px] 2xl:min-w-[420px] 2xl:pt-4">
+          <section className="flex w-full shrink-0 items-center justify-center lg:w-auto lg:min-w-[340px] lg:justify-end lg:self-center xl:min-w-[380px] 2xl:min-w-[420px] 2xl:pt-4">
             <CardPreview card={card} />
           </section>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import clsx from "classnames";
+
 import { CardEditor } from "@/app/components/CardEditor";
 import { CardPreview } from "@/app/components/CardPreview";
 import { DeckBuilder } from "@/app/components/DeckBuilder";
@@ -22,54 +24,114 @@ const initialCard: CardFormValues = {
   version: "v1.0.0"
 };
 
+type WorkspaceId = "card-editor" | "deck-check" | "export" | "keyword";
+
+const WORKSPACES: Array<{
+  id: WorkspaceId;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "card-editor",
+    label: "Card Editor",
+    description: "Design and validate individual cards"
+  },
+  {
+    id: "deck-check",
+    label: "Deck Check",
+    description: "Assemble decks and confirm legality"
+  },
+  {
+    id: "export",
+    label: "Export",
+    description: "Package cards for sharing"
+  },
+  {
+    id: "keyword",
+    label: "Keyword",
+    description: "Manage shared terminology"
+  }
+];
+
 export default function HomePage() {
   const [card, setCard] = useState<CardFormValues>(initialCard);
+  const [activeWorkspace, setActiveWorkspace] = useState<WorkspaceId>("card-editor");
 
   return (
-    <main className="workspace-shell">
-      <div className="space-y-10">
-        <header className="dashboard-header">
-          <div className="space-y-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-primary-200">Design &amp; Validation Hub</p>
-            <div className="space-y-2">
-              <h1 className="text-4xl font-semibold text-white sm:text-5xl">CardForge</h1>
-              <p className="max-w-3xl text-base text-slate-300">
-                Det kompletta gränssnittet för att bygga kort, kontrollera lekar och hålla ordning på nyckelord – allt i
-                en arbetsvy anpassad för både prototypande och turneringsförberedelser.
-              </p>
+    <main className="flex min-h-screen bg-neutral-200 text-slate-900">
+      <aside className="flex w-72 flex-col justify-between border-r border-slate-300 bg-white/80 px-6 py-10 shadow-md">
+        <div className="space-y-10">
+          <div className="flex items-center gap-3">
+            <span className="flex h-14 w-14 items-center justify-center rounded-full bg-slate-900 text-lg font-semibold text-white">
+              PFP
+            </span>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Workspace</p>
+              <h1 className="text-2xl font-semibold">CardForge</h1>
             </div>
           </div>
-          <dl className="dashboard-metrics">
-            <div>
-              <dt>Validator</dt>
-              <dd>Zod-powered schemas</dd>
-            </div>
-            <div>
-              <dt>Nyckelord</dt>
-              <dd>Delat bibliotek</dd>
-            </div>
-            <div>
-              <dt>Formatstöd</dt>
-              <dd>Standard &amp; Unlimited</dd>
-            </div>
-            <div>
-              <dt>Export</dt>
-              <dd>JSON · PNG · PDF</dd>
-            </div>
-          </dl>
-        </header>
 
-        <section className="dashboard-grid">
-          <div className="space-y-8">
-            <CardEditor onChange={setCard} />
-            <DeckBuilder />
-          </div>
-          <div className="space-y-8">
+          <nav className="space-y-2">
+            {WORKSPACES.map((workspace) => (
+              <button
+                key={workspace.id}
+                type="button"
+                onClick={() => setActiveWorkspace(workspace.id)}
+                className={clsx(
+                  "flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-left transition",
+                  activeWorkspace === workspace.id
+                    ? "bg-primary-500 text-white shadow-lg shadow-primary-200/60"
+                    : "text-slate-600 hover:bg-white"
+                )}
+              >
+                <span
+                  className={clsx(
+                    "flex h-10 w-10 items-center justify-center rounded-full border text-sm font-semibold",
+                    activeWorkspace === workspace.id
+                      ? "border-white/60 bg-white/20"
+                      : "border-slate-300 bg-white text-slate-600"
+                  )}
+                >
+                  {workspace.label
+                    .split(" ")
+                    .map((word) => word[0])
+                    .join("")}
+                </span>
+                <div>
+                  <p className="text-sm font-semibold">{workspace.label}</p>
+                  <p className="text-xs text-slate-500">
+                    {workspace.description}
+                  </p>
+                </div>
+              </button>
+            ))}
+          </nav>
+        </div>
+
+        <button
+          type="button"
+          className="flex items-center gap-3 rounded-2xl px-3 py-3 text-sm font-semibold text-slate-600 transition hover:bg-white"
+        >
+          <span className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-300 bg-white text-xs font-semibold uppercase tracking-wider">
+            ⚙️
+          </span>
+          Settings
+        </button>
+      </aside>
+
+      <div className="flex flex-1 items-start justify-center px-10 py-12">
+        <div className="grid w-full max-w-6xl gap-10 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)]">
+          <section className="flex flex-col gap-6">
+            {activeWorkspace === "card-editor" ? <CardEditor onChange={setCard} /> : null}
+            {activeWorkspace === "deck-check" ? <DeckBuilder /> : null}
+            {activeWorkspace === "export" ? <ExportPanel card={card} /> : null}
+            {activeWorkspace === "keyword" ? <KeywordManager /> : null}
+          </section>
+
+          <section className="flex items-start justify-center">
             <CardPreview card={card} />
-            <ExportPanel card={card} />
-            <KeywordManager />
-          </div>
-        </section>
+          </section>
+        </div>
       </div>
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import clsx from "classnames";
 
 import { CardEditor } from "@/app/components/CardEditor";
@@ -56,40 +56,81 @@ const WORKSPACES: Array<{
 export default function HomePage() {
   const [card, setCard] = useState<CardFormValues>(initialCard);
   const [activeWorkspace, setActiveWorkspace] = useState<WorkspaceId>("card-editor");
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const settingsRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("cardforge-theme");
+    if (stored === "light" || stored === "dark") {
+      setTheme(stored);
+      return;
+    }
+    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      setTheme("dark");
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.style.colorScheme = theme;
+    window.localStorage.setItem("cardforge-theme", theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (!isSettingsOpen) return;
+    function handleClick(event: MouseEvent) {
+      if (!settingsRef.current?.contains(event.target as Node)) {
+        setIsSettingsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [isSettingsOpen]);
+
+  function handleWorkspaceSelect(workspaceId: WorkspaceId) {
+    setActiveWorkspace(workspaceId);
+    setIsSettingsOpen(false);
+  }
+
+  function toggleTheme() {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  }
 
   return (
-    <main className="flex min-h-screen bg-neutral-200 text-slate-900">
-      <aside className="flex w-72 flex-col justify-between border-r border-slate-300 bg-white/80 px-6 py-10 shadow-md">
-        <div className="space-y-10">
+    <main className="flex min-h-screen flex-col text-slate-900 transition-colors dark:text-slate-100 lg:flex-row">
+      <aside className="relative z-10 flex w-full flex-col justify-between gap-8 border-b border-slate-300/60 bg-white/80 px-6 py-6 shadow-sm backdrop-blur-lg transition dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-black/30 lg:h-screen lg:w-72 lg:border-b-0 lg:border-r lg:px-6 lg:py-10 lg:shadow-md">
+        <div className="space-y-8">
           <div className="flex items-center gap-3">
-            <span className="flex h-14 w-14 items-center justify-center rounded-full bg-slate-900 text-lg font-semibold text-white">
+            <span className="flex h-14 w-14 items-center justify-center rounded-full bg-slate-900 text-lg font-semibold text-white dark:bg-slate-700">
               PFP
             </span>
             <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Workspace</p>
-              <h1 className="text-2xl font-semibold">CardForge</h1>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">Workspace</p>
+              <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">CardForge</h1>
             </div>
           </div>
 
-          <nav className="space-y-2">
+          <nav className="grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
             {WORKSPACES.map((workspace) => (
               <button
                 key={workspace.id}
                 type="button"
-                onClick={() => setActiveWorkspace(workspace.id)}
+                onClick={() => handleWorkspaceSelect(workspace.id)}
                 className={clsx(
-                  "flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-left transition",
+                  "flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-left transition focus-visible:outline-none",
                   activeWorkspace === workspace.id
-                    ? "bg-primary-500 text-white shadow-lg shadow-primary-200/60"
-                    : "text-slate-600 hover:bg-white"
+                    ? "bg-primary-500 text-white shadow-lg shadow-primary-200/60 dark:bg-primary-600 dark:shadow-primary-900/40"
+                    : "text-slate-600 hover:bg-white/70 dark:text-slate-300 dark:hover:bg-slate-800/80"
                 )}
               >
                 <span
                   className={clsx(
-                    "flex h-10 w-10 items-center justify-center rounded-full border text-sm font-semibold",
+                    "flex h-10 w-10 items-center justify-center rounded-full border text-sm font-semibold transition",
                     activeWorkspace === workspace.id
-                      ? "border-white/60 bg-white/20"
-                      : "border-slate-300 bg-white text-slate-600"
+                      ? "border-white/60 bg-white/20 text-white"
+                      : "border-slate-300 bg-white text-slate-600 dark:border-slate-600 dark:bg-slate-900/60 dark:text-slate-300"
                   )}
                 >
                   {workspace.label
@@ -98,8 +139,8 @@ export default function HomePage() {
                     .join("")}
                 </span>
                 <div>
-                  <p className="text-sm font-semibold">{workspace.label}</p>
-                  <p className="text-xs text-slate-500">
+                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{workspace.label}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
                     {workspace.description}
                   </p>
                 </div>
@@ -108,27 +149,58 @@ export default function HomePage() {
           </nav>
         </div>
 
-        <button
-          type="button"
-          className="flex items-center gap-3 rounded-2xl px-3 py-3 text-sm font-semibold text-slate-600 transition hover:bg-white"
-        >
-          <span className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-300 bg-white text-xs font-semibold uppercase tracking-wider">
-            ⚙️
-          </span>
-          Settings
-        </button>
+        <div ref={settingsRef} className="relative">
+          <button
+            type="button"
+            onClick={() => setIsSettingsOpen((prev) => !prev)}
+            className="flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-sm font-semibold text-slate-600 transition hover:bg-white/70 dark:text-slate-300 dark:hover:bg-slate-800/80"
+          >
+            <span className="flex h-10 w-10 items-center justify-center rounded-full border border-slate-300 bg-white text-xs font-semibold uppercase tracking-wider text-slate-600 dark:border-slate-600 dark:bg-slate-900/70 dark:text-slate-300">
+              ⚙️
+            </span>
+            Settings
+          </button>
+
+          {isSettingsOpen ? (
+            <div className="absolute bottom-16 left-0 right-0 z-20 space-y-4 rounded-2xl border border-slate-200 bg-white/95 p-4 text-sm shadow-xl dark:border-slate-700 dark:bg-slate-900/95">
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">Appearance</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Toggle CardForge between light and dark surfaces to suit your environment.
+                </p>
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">{theme === "dark" ? "Dark mode" : "Light mode"}</span>
+                <button
+                  type="button"
+                  onClick={toggleTheme}
+                  aria-label="Toggle dark mode"
+                  aria-pressed={theme === "dark"}
+                  className={clsx(
+                    "flex h-9 w-16 items-center rounded-full px-1 transition focus-visible:outline focus-visible:outline-primary-400",
+                    theme === "dark" ? "justify-end bg-primary-500" : "justify-start bg-slate-300"
+                  )}
+                >
+                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-white text-base shadow-sm">
+                    {theme === "dark" ? "🌙" : "☀️"}
+                  </span>
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </div>
       </aside>
 
-      <div className="flex flex-1 items-start justify-center px-10 py-12">
-        <div className="grid w-full max-w-6xl gap-10 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)]">
-          <section className="flex flex-col gap-6">
+      <div className="flex flex-1 justify-center px-4 py-8 sm:px-6 lg:px-10 lg:py-12">
+        <div className="flex w-full max-w-6xl flex-col gap-8 xl:grid xl:grid-cols-[minmax(0,1.25fr)_minmax(0,0.9fr)] xl:items-start xl:gap-10">
+          <section className="order-1 flex flex-col gap-6">
             {activeWorkspace === "card-editor" ? <CardEditor onChange={setCard} /> : null}
             {activeWorkspace === "deck-check" ? <DeckBuilder /> : null}
             {activeWorkspace === "export" ? <ExportPanel card={card} /> : null}
             {activeWorkspace === "keyword" ? <KeywordManager /> : null}
           </section>
 
-          <section className="flex items-start justify-center">
+          <section className="order-2 flex items-start justify-center xl:order-none xl:justify-end">
             <CardPreview card={card} />
           </section>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -100,7 +100,7 @@ export default function HomePage() {
 
   return (
     <main className="flex min-h-screen flex-col text-slate-900 transition-colors dark:text-slate-100 lg:flex-row">
-      <aside className="relative z-10 flex w-full flex-col justify-between gap-8 border-b border-slate-300/60 bg-white/80 px-6 py-6 shadow-sm backdrop-blur-lg transition dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-black/30 lg:h-screen lg:w-72 lg:border-b-0 lg:border-r lg:px-6 lg:py-10 lg:shadow-md">
+      <aside className="relative z-10 flex w-full flex-col justify-between gap-8 border-b border-slate-300/60 bg-white/80 px-6 py-6 shadow-sm backdrop-blur-lg transition dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-black/30 sm:px-8 lg:h-screen lg:w-80 lg:border-b-0 lg:border-r lg:px-8 lg:py-12 lg:shadow-md xl:gap-10 2xl:w-[24rem] 2xl:px-10 2xl:py-16">
         <div className="space-y-8">
           <div className="flex items-center gap-3">
             <span className="flex h-14 w-14 items-center justify-center rounded-full bg-slate-900 text-lg font-semibold text-white dark:bg-slate-700">
@@ -112,7 +112,7 @@ export default function HomePage() {
             </div>
           </div>
 
-          <nav className="grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
+          <nav className="grid gap-2 sm:grid-cols-2 lg:grid-cols-1 xl:gap-3 2xl:gap-4">
             {WORKSPACES.map((workspace) => (
               <button
                 key={workspace.id}
@@ -191,16 +191,16 @@ export default function HomePage() {
         </div>
       </aside>
 
-      <div className="flex flex-1 justify-center px-4 py-8 sm:px-6 lg:px-10 lg:py-12">
-        <div className="flex w-full max-w-6xl flex-col gap-8 lg:flex-row lg:items-start lg:gap-12 xl:max-w-7xl">
-          <section className="flex min-w-0 flex-[1.6] flex-col gap-6">
+      <div className="flex flex-1 justify-center px-4 py-8 sm:px-6 lg:px-12 lg:py-12 2xl:px-16 2xl:py-16">
+        <div className="flex w-full max-w-5xl flex-col gap-8 lg:flex-row lg:items-start lg:gap-12 xl:max-w-[1400px] 2xl:max-w-[1600px] 2xl:gap-16">
+          <section className="flex min-w-0 flex-[1.7] flex-col gap-6 2xl:gap-8">
             {activeWorkspace === "card-editor" ? <CardEditor onChange={setCard} /> : null}
             {activeWorkspace === "deck-check" ? <DeckBuilder /> : null}
             {activeWorkspace === "export" ? <ExportPanel card={card} /> : null}
             {activeWorkspace === "keyword" ? <KeywordManager /> : null}
           </section>
 
-          <section className="flex w-full shrink-0 justify-center lg:w-auto lg:justify-end">
+          <section className="flex w-full shrink-0 justify-center lg:w-auto lg:min-w-[340px] lg:justify-end xl:min-w-[380px] 2xl:min-w-[420px] 2xl:pt-4">
             <CardPreview card={card} />
           </section>
         </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: "class",
   content: [
     "./app/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -14,12 +18,28 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- Implemented a sidebar-focused workspace layout with dynamic tool selection and a persistent card preview that matches the provided wireframe.
- Refreshed the global styling palette to a light neutral theme and updated the card preview to present clean white cards.
- Updated the editor, deck, export, and keyword tooling panels to adopt the new styling while keeping their existing behaviors.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb0f218378832ba63d28778541f15f